### PR TITLE
chore: Add clippy and fix some lint warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,15 @@ jobs:
         run: cargo update
       - name: Run Cargo Tests
         run: cargo test
+  lint:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
+      - name: Update cargo
+        run: cargo update
+      - name: Lint
+        run: cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
+

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -11,7 +11,7 @@ pub enum CheckResult {
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum FailureReason {
-    TIMEOUT,
+    Timeout,
     DnsError(String),
     Error(String),
 }
@@ -37,7 +37,7 @@ pub async fn check_url(client: &reqwest::Client, url: String) -> CheckResult {
         Ok(_) => CheckResult::Success,
         Err(e) => {
             if e.is_timeout() {
-                return CheckResult::Failure(FailureReason::TIMEOUT);
+                return CheckResult::Failure(FailureReason::Timeout);
             }
             // TODO: More reasons
             let mut inner = &e as &dyn Error;
@@ -101,7 +101,7 @@ mod tests {
         );
         assert_eq!(
             check_url(&client, server.url("/timeout")).await,
-            CheckResult::Failure(FailureReason::TIMEOUT)
+            CheckResult::Failure(FailureReason::Timeout)
         );
         head_mock.assert();
         head_disallowed_mock.assert();

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -11,7 +11,7 @@ pub enum CheckResult {
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum FailureReason {
-    Timeout,
+    TIMEOUT,
     DnsError(String),
     Error(String),
 }
@@ -37,7 +37,7 @@ pub async fn check_url(client: &reqwest::Client, url: String) -> CheckResult {
         Ok(_) => CheckResult::Success,
         Err(e) => {
             if e.is_timeout() {
-                return CheckResult::Failure(FailureReason::Timeout);
+                return CheckResult::Failure(FailureReason::TIMEOUT);
             }
             // TODO: More reasons
             let mut inner = &e as &dyn Error;
@@ -101,7 +101,7 @@ mod tests {
         );
         assert_eq!(
             check_url(&client, server.url("/timeout")).await,
-            CheckResult::Failure(FailureReason::Timeout)
+            CheckResult::Failure(FailureReason::TIMEOUT)
         );
         head_mock.assert();
         head_disallowed_mock.assert();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+// TODO: We might want to remove this once more stable, but it's just noisy for now.
+#![allow(dead_code)]
 mod checker;
 mod cli;
 mod cliapp;


### PR DESCRIPTION
This adds a lint action for GHA. Also fixes some warnings turned up by clippy, and disables dead code warnings for this crate.