### PR TITLE
fix: Fix missing libgcc in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ FROM alpine:3.20
 
 COPY --from=builder /app/target/release/uptime-checker /usr/local/bin/uptime-checker
 
-RUN apk add --no-cache tini
+RUN apk add --no-cache tini libgcc
 
 RUN addgroup -S app && adduser -S app -G app
 USER app


### PR DESCRIPTION
This needs to be installed in the build container to fix `Error loading shared library libgcc_s.so.1: No such file or directory (needed by /usr/local/bin/uptime-checker`