### PR TITLE
feat(uptime): Update `sentry-kafka-schemas`, remove monitor ids and add subscription_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2542,9 +2542,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "0.1.91"
+version = "0.1.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e967beec2f3e4745a5aba479570c07b9d08b77ba57daacaffd892cf434eaa6f8"
+checksum = "1c1d7548b0389922e5bf6af4f6d99067de8b24e1961f861f964b7bfe4c61ae18"
 dependencies = [
  "jsonschema",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ thiserror = "1.0.61"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json"] }
 console = "0.15.8"
-sentry-kafka-schemas = "0.1.91"
+sentry-kafka-schemas = "0.1.93"
 
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -123,8 +123,8 @@ impl Checker {
 
         CheckResult {
             guid: Uuid::new_v4(),
-            monitor_id: 0,
-            monitor_environment_id: 0,
+            // TODO: Use the real subscription id here when we have it
+            subscription_id: Uuid::new_v4(),
             status,
             status_reason,
             trace_id,

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,7 +1,7 @@
 use reqwest::{Client, ClientBuilder, Response, StatusCode};
 use std::{error::Error, time::Duration};
 use tokio::time::Instant;
-use uuid::Uuid;
+use uuid::{Uuid, uuid};
 
 use crate::types::{
     CheckResult, CheckStatus, CheckStatusReason, CheckStatusReasonType, RequestInfo, RequestType,
@@ -25,6 +25,8 @@ impl Default for CheckerConfig {
 pub struct Checker {
     client: Client,
 }
+
+pub const SUBSCRIPTION_ID: Uuid = uuid!("663399a09e6340a79c3c7a3f26878904");
 
 /// Fetches the response from a URL.
 ///
@@ -124,7 +126,7 @@ impl Checker {
         CheckResult {
             guid: Uuid::new_v4(),
             // TODO: Use the real subscription id here when we have it
-            subscription_id: Uuid::new_v4(),
+            subscription_id: SUBSCRIPTION_ID,
             status,
             status_reason,
             trace_id,

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -63,13 +63,14 @@ mod tests {
         RequestType,
     };
     use rust_arroyo::backends::kafka::config::KafkaConfig;
-    use uuid::Uuid;
+    use uuid::{Uuid};
+    use crate::checker::SUBSCRIPTION_ID;
 
     pub async fn send_result(result: CheckStatus) -> Result<(), ExtractCodeError> {
         let guid = Uuid::new_v4();
         let result = CheckResult {
             guid,
-            subscription_id: Uuid::new_v4(),
+            subscription_id: SUBSCRIPTION_ID,
             status: result,
             status_reason: Some(CheckStatusReason {
                 status_type: CheckStatusReasonType::DnsError,

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -69,8 +69,7 @@ mod tests {
         let guid = Uuid::new_v4();
         let result = CheckResult {
             guid,
-            monitor_id: 123,
-            monitor_environment_id: 456,
+            subscription_id: Uuid::new_v4(),
             status: result,
             status_reason: Some(CheckStatusReason {
                 status_type: CheckStatusReasonType::DnsError,

--- a/src/types.rs
+++ b/src/types.rs
@@ -64,11 +64,8 @@ pub struct CheckResult {
     #[serde(serialize_with = "uuid_simple")]
     pub guid: Uuid,
 
-    /// The identifier of the uptime monitor
-    pub monitor_id: u64,
-
-    /// The identifier of the uptime monitors environment
-    pub monitor_environment_id: u64,
+    /// The identifier of the subscription
+    pub subscription_id: Uuid,
 
     /// The status of the check
     pub status: CheckStatus,
@@ -103,8 +100,7 @@ mod tests {
     fn serialize_json_roundtrip_failure_example() {
         let json = r#"{
   "guid": "54afc7ed9c53491481919c931f75bae1",
-  "monitor_id": 1,
-  "monitor_environment_id": 1,
+  "susbcription_id": "23d6048d67c948d9a19c0b47979e9a03",
   "status": "failure",
   "status_reason": {
     "type": "dns_error",
@@ -130,8 +126,7 @@ mod tests {
     fn serialize_json_roundtrip_success_example() {
         let json = r#"{
   "guid": "54afc7ed9c53491481919c931f75bae1",
-  "monitor_id": 1,
-  "monitor_environment_id": 1,
+  "subscription_id": "23d6048d67c948d9a19c0b47979e9a03"
   "status": "success",
   "status_reason": null,
   "trace_id": "947efba02dac463b9c1d886a44bafc94",

--- a/src/types.rs
+++ b/src/types.rs
@@ -65,6 +65,7 @@ pub struct CheckResult {
     pub guid: Uuid,
 
     /// The identifier of the subscription
+    #[serde(serialize_with = "uuid_simple")]
     pub subscription_id: Uuid,
 
     /// The status of the check
@@ -100,7 +101,7 @@ mod tests {
     fn serialize_json_roundtrip_failure_example() {
         let json = r#"{
   "guid": "54afc7ed9c53491481919c931f75bae1",
-  "susbcription_id": "23d6048d67c948d9a19c0b47979e9a03",
+  "subscription_id": "23d6048d67c948d9a19c0b47979e9a03",
   "status": "failure",
   "status_reason": {
     "type": "dns_error",
@@ -126,7 +127,7 @@ mod tests {
     fn serialize_json_roundtrip_success_example() {
         let json = r#"{
   "guid": "54afc7ed9c53491481919c931f75bae1",
-  "subscription_id": "23d6048d67c948d9a19c0b47979e9a03"
+  "subscription_id": "23d6048d67c948d9a19c0b47979e9a03",
   "status": "success",
   "status_reason": null,
   "trace_id": "947efba02dac463b9c1d886a44bafc94",


### PR DESCRIPTION
This updates the checker to use `subscription_id` instead of monitor ids