### PR TITLE
feat: Schedule executions from the ConfigStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,17 +610,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
-name = "cron"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
-dependencies = [
- "chrono",
- "nom",
- "once_cell",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,17 +1679,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "num-integer"
@@ -3091,21 +3069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-cron-scheduler"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c2e3a88f827f597799cf70a6f673074e62f3fc5ba5993b2873345c618a29af"
-dependencies = [
- "chrono",
- "cron",
- "num-derive",
- "num-traits",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3386,7 +3349,6 @@ dependencies = [
  "similar-asserts",
  "thiserror",
  "tokio",
- "tokio-cron-scheduler",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ httpmock = "0.7.0-rc.1"
 reqwest = "0.12.4"
 rust_arroyo = { version = "*", git = "https://github.com/getsentry/arroyo" }
 tokio = { version = "1.28.0", features = ["macros", "sync", "tracing", "signal", "rt-multi-thread"] }
-tokio-cron-scheduler = "0.10.2"
 uuid = { version = "1.8.0", features = ["serde", "v4"] }
 serde = { version = "1.0.159", features = ["derive", "rc"] }
 serde_json = "1.0.93"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,14 +1,17 @@
-use std::io;
+use std::{io, sync::Arc, time::Duration};
 
 use clap::Parser;
 use tokio::signal::ctrl_c;
 use tracing::info;
+use uuid::uuid;
 
 use crate::{
     cliapp::{CliApp, Commands},
     config::Config,
+    config_store::ConfigStore,
     logging::{self, LoggingConfig},
     scheduler::run_scheduler,
+    types::check_config::{CheckConfig, CheckInterval},
 };
 
 pub fn execute() -> io::Result<()> {
@@ -19,13 +22,23 @@ pub fn execute() -> io::Result<()> {
 
     info!(config = ?config);
 
+    let mut config_store = ConfigStore::new();
+
+    // XXX: Example config while we build out the consumer that loads configs
+    config_store.add_config(Arc::new(CheckConfig {
+        url: "https://downtime-simulator-test1.vercel.app".to_string(),
+        subscription_id: uuid!("663399a09e6340a79c3c7a3f26878904"),
+        interval: CheckInterval::FiveMinutes,
+        timeout: Duration::from_secs(5),
+    }));
+
     match app.command {
         Commands::Run => tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .unwrap()
             .block_on(async {
-                run_scheduler(&config)
+                run_scheduler(&config, Arc::new(config_store))
                     .await
                     .expect("Failed to run scheduler");
                 ctrl_c().await


### PR DESCRIPTION
Connects the `ConfigStore` to the scheduler.

The scheduler will now read all `CheckConfig`s at the given tick and create futures to execute each check.

I've also removed the `tokio-cron-scheduler` package in favor of using `tokio`s build in `Interval` to generate our ticks

The example config has now moved the the root cli runner for now