### PR TITLE
ref(config-store): Track partitions of configs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -28,6 +28,7 @@ pub fn execute() -> io::Result<()> {
 
     // XXX: Example config while we build out the consumer that loads configs
     config_store.add_config(Arc::new(CheckConfig {
+        partition: 0,
         url: "https://downtime-simulator-test1.vercel.app".to_string(),
         subscription_id: uuid!("663399a09e6340a79c3c7a3f26878904"),
         interval: CheckInterval::FiveMinutes,

--- a/src/config_store.rs
+++ b/src/config_store.rs
@@ -1,23 +1,20 @@
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-    sync::Arc,
-};
+use std::{collections::HashMap, fmt, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::types::check_config::{CheckConfig, MAX_CHECK_INTERVAL_SECS};
 
-/// Maps the unique subscription_id of a CheckConfig to the configuration itself. This provides
-/// O(1) access during configuration updates.
-pub type CheckerConfigs = HashMap<Uuid, Arc<CheckConfig>>;
+// Represents a bucket of checks at a given tick.
+pub type TickBucket = Vec<Arc<CheckConfig>>;
 
-/// The TickBucket is used to determine which checks should be executed at which ticks along the
+/// TickBuckets are used to determine which checks should be executed at which ticks along the
 /// interval pattern. Each tick contains the set of checks that are assigned to that second.
-pub type TickBuckets = Vec<HashSet<Uuid>>;
+pub type TickBuckets = Vec<TickBucket>;
 
-/// Ticks represnet a location within the TickBuckets. They are guaranteed to be within the
+pub type PartitionedTickBuckets = HashMap<i32, TickBuckets>;
+
+/// Ticks represent a location within the TickBuckets. They are guaranteed to be within the
 /// MAX_CHECK_INTERVAL_SECS range.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Tick {
@@ -25,6 +22,8 @@ pub struct Tick {
     time: DateTime<Utc>,
 }
 
+/// Represents a slot within the TickBuckets. Ticks are used to determine which checks should be
+/// executed at which ticks along the interval pattern.
 impl Tick {
     /// Used primarily in tests to create a tick. Does not grantee invariants.
     #[doc(hidden)]
@@ -60,20 +59,27 @@ impl fmt::Display for Tick {
 
 /// The ConfigStore maintains the state of all check configurations and provides an efficient way
 /// to retrieve the checks that are scheduled for a given tick.
+///
+/// CheckConfigs are stored into TickBuckets based on their interval. Each bucket contains the
+/// checks that should be executed at that tick. Each configuration includes the partition it
+/// belongs to, the ConfigStore will group configurations by partition and supports dropping entire
+/// partitions of CheckConfigs.
 #[derive(Debug)]
 pub struct ConfigStore {
-    buckets: TickBuckets,
-    configs: CheckerConfigs,
+    /// A ConfigStore is derived from configurations loaded from Kafka, when the assigned
+    /// partitions for the uptime-checker are re-balanced, partitions will be added and removed.
+    /// Storing TickBuckets for each partition makes dropping an entire partition of configs during
+    /// removal simple.
+    partitioned_buckets: HashMap<i32, TickBuckets>,
+
+    /// Mapping of each subscription_id's config
+    configs: HashMap<Uuid, Arc<CheckConfig>>,
 }
 
 impl ConfigStore {
     pub fn new() -> ConfigStore {
-        let buckets = (0..MAX_CHECK_INTERVAL_SECS)
-            .map(|_| HashSet::new())
-            .collect();
-
         ConfigStore {
-            buckets,
+            partitioned_buckets: HashMap::new(),
             configs: HashMap::new(),
         }
     }
@@ -82,26 +88,50 @@ impl ConfigStore {
     pub fn add_config(&mut self, config: Arc<CheckConfig>) {
         self.configs.insert(config.subscription_id, config.clone());
 
+        let bucket = self
+            .partitioned_buckets
+            .entry(config.partition)
+            .or_insert_with(|| (0..MAX_CHECK_INTERVAL_SECS).map(|_| vec![]).collect());
+
         // Insert the configuration into the appropriate slots
         for slot in config.slots() {
-            self.buckets[slot].insert(config.subscription_id);
+            bucket[slot].push(config.clone());
         }
     }
 
     /// Remove a Check Configuration from the store.
     pub fn remove_config(&mut self, subscription_id: Uuid) {
-        if let Some(config) = self.configs.remove(&subscription_id) {
-            for slot in config.slots() {
-                self.buckets[slot].remove(&subscription_id);
-            }
+        let Some(config) = self.configs.remove(&subscription_id) else {
+            return;
+        };
+        let Some(buckets) = self.partitioned_buckets.get_mut(&config.partition) else {
+            return;
+        };
+
+        for slot in config.slots() {
+            buckets[slot].retain(|c| c.subscription_id != subscription_id);
         }
     }
 
-    /// Get all check configs that are scheduled for a given tick.
-    pub fn get_configs(&self, tick: Tick) -> Vec<Arc<CheckConfig>> {
-        self.buckets[tick.index]
+    /// Drop an entire partition of check configurations.
+    pub fn drop_partition(&mut self, partition: i32) {
+        let Some(buckets) = self.partitioned_buckets.remove(&partition) else {
+            return;
+        };
+
+        buckets
             .iter()
-            .filter_map(|id| self.configs.get(id).cloned())
+            .flat_map(|b| b.iter().cloned())
+            .for_each(|config| {
+                self.configs.remove(&config.subscription_id);
+            });
+    }
+
+    /// Get all check configs that are scheduled for a given tick.
+    pub fn get_configs(&self, tick: Tick) -> TickBucket {
+        self.partitioned_buckets
+            .values()
+            .flat_map(move |b| b[tick.index].iter().cloned())
             .collect()
     }
 }
@@ -119,7 +149,7 @@ mod tests {
     };
 
     #[test]
-    pub fn test_tick_for_time() {
+    fn test_tick_for_time() {
         let time = DateTime::from_timestamp(0, 0).unwrap();
         assert_eq!(Tick::from_time(time).index, 0);
 
@@ -134,15 +164,15 @@ mod tests {
     }
 
     #[test]
-    pub fn test_add_config() {
+    fn test_add_config() {
         let mut store = ConfigStore::new();
 
         let config = Arc::new(CheckConfig::default());
         store.add_config(config.clone());
 
         assert_eq!(store.configs.len(), 1);
-        assert_eq!(store.buckets[0].len(), 1);
-        assert_eq!(store.buckets[60].len(), 1);
+        assert_eq!(store.partitioned_buckets[&0][0].len(), 1);
+        assert_eq!(store.partitioned_buckets[&0][60].len(), 1);
 
         // Another config with a 5 min interval should be in every 5th slot
         let five_minute_config = Arc::new(CheckConfig {
@@ -155,10 +185,17 @@ mod tests {
         });
         store.add_config(five_minute_config.clone());
 
+        let second_partiton_config = Arc::new(CheckConfig {
+            partition: 2,
+            ..Default::default()
+        });
+        store.add_config(second_partiton_config.clone());
+
         assert_eq!(store.configs.len(), 2);
-        assert_eq!(store.buckets[0].len(), 2);
-        assert_eq!(store.buckets[60].len(), 1);
-        assert_eq!(store.buckets[60 * 5].len(), 2);
+        assert_eq!(store.partitioned_buckets[&0][0].len(), 2);
+        assert_eq!(store.partitioned_buckets[&0][60].len(), 1);
+        assert_eq!(store.partitioned_buckets[&0][60 * 5].len(), 2);
+        assert_eq!(store.partitioned_buckets[&2][0].len(), 1);
     }
 
     #[test]
@@ -177,18 +214,18 @@ mod tests {
 
         store.remove_config(config.subscription_id);
         assert_eq!(store.configs.len(), 1);
-        assert_eq!(store.buckets[0].len(), 1);
-        assert_eq!(store.buckets[60].len(), 0);
-        assert_eq!(store.buckets[60 * 5].len(), 1);
+        assert_eq!(store.partitioned_buckets[&0][0].len(), 1);
+        assert_eq!(store.partitioned_buckets[&0][60].len(), 0);
+        assert_eq!(store.partitioned_buckets[&0][60 * 5].len(), 1);
 
         store.remove_config(five_minute_config.subscription_id);
         assert_eq!(store.configs.len(), 0);
-        assert_eq!(store.buckets[0].len(), 0);
-        assert_eq!(store.buckets[60 * 5].len(), 0);
+        assert_eq!(store.partitioned_buckets[&0][0].len(), 0);
+        assert_eq!(store.partitioned_buckets[&0][60 * 5].len(), 0);
     }
 
     #[test]
-    pub fn test_get_configs() {
+    fn test_get_configs() {
         let mut store = ConfigStore::new();
 
         let config = Arc::new(CheckConfig::default());
@@ -201,12 +238,50 @@ mod tests {
         });
         store.add_config(five_minute_config.clone());
 
+        let second_partiton_config = Arc::new(CheckConfig {
+            partition: 2,
+            subscription_id: Uuid::from_u128(MAX_CHECK_INTERVAL_SECS as u128 * 2),
+            ..Default::default()
+        });
+        store.add_config(second_partiton_config.clone());
+
         let configs = store.get_configs(Tick::new(0, Utc::now()));
-        assert_eq!(configs.len(), 2);
+        assert_eq!(configs.len(), 3);
         assert!(configs.contains(&config));
         assert!(configs.contains(&five_minute_config));
+        assert!(configs.contains(&second_partiton_config));
 
         let no_configs = store.get_configs(Tick::new(1, Utc::now()));
         assert!(no_configs.is_empty());
+    }
+
+    #[test]
+    fn test_drop_partition() {
+        let mut store = ConfigStore::new();
+
+        let config = Arc::new(CheckConfig::default());
+        store.add_config(config.clone());
+
+        let five_minute_config = Arc::new(CheckConfig {
+            subscription_id: Uuid::from_u128(MAX_CHECK_INTERVAL_SECS as u128),
+            interval: CheckInterval::FiveMinutes,
+            ..Default::default()
+        });
+        store.add_config(five_minute_config.clone());
+
+        let second_partiton_config = Arc::new(CheckConfig {
+            partition: 2,
+            subscription_id: Uuid::from_u128(MAX_CHECK_INTERVAL_SECS as u128 * 2),
+            ..Default::default()
+        });
+        store.add_config(second_partiton_config.clone());
+
+        assert_eq!(store.configs.len(), 3);
+        assert_eq!(store.partitioned_buckets.len(), 2);
+
+        store.drop_partition(2);
+        assert_eq!(store.configs.len(), 2);
+        assert_eq!(store.partitioned_buckets.len(), 1);
+        assert!(store.partitioned_buckets.contains_key(&0));
     }
 }

--- a/src/types/check_config.rs
+++ b/src/types/check_config.rs
@@ -25,6 +25,10 @@ pub const MAX_CHECK_INTERVAL_SECS: usize = CheckInterval::SixtyMinutes as usize;
 #[serde_as]
 #[derive(Debug, PartialEq, Clone, Deserialize)]
 pub struct CheckConfig {
+    /// The kafka partition this config is associated to.
+    #[serde(skip)]
+    pub partition: i32,
+
     /// The subscription this check configuration is associated to in sentry.
     #[serde(with = "uuid::serde::simple")]
     pub subscription_id: Uuid,
@@ -76,6 +80,7 @@ mod tests {
     impl Default for CheckConfig {
         fn default() -> Self {
             CheckConfig {
+                partition: 0,
                 subscription_id: Uuid::from_u128(0),
                 interval: CheckInterval::OneMinute,
                 timeout: TimeDelta::seconds(10),
@@ -102,6 +107,7 @@ mod tests {
         assert_eq!(
             rmp_serde::from_slice::<CheckConfig>(&example).unwrap(),
             CheckConfig {
+                partition: 0,
                 subscription_id: uuid!("d7629c6c-82be-4f67-9ee7-8a0d977856d2"),
                 timeout: TimeDelta::milliseconds(500),
                 interval: CheckInterval::FiveMinutes,


### PR DESCRIPTION
Since we'll be using kafka to store and receive configurations, each config will be part of a kafka partiton. These can be added or removed from the checker during rebalancing, thus we need to support dropping a set of configurations all at once when a partition is removed.

The ConfigStore has learned `drop_partition`, which drops all CheckConfigs associated to a particular partition. It does this efficiently by keeping a TickBuckets list for each partition. When a partition is dropped the entire TickBuckets vector is dropped and all CheckConfigs contained in those buckets are dropped