### PR TITLE
feat(check-config): Make the store RwLock-able

### DIFF
--- a/src/config_store.rs
+++ b/src/config_store.rs
@@ -1,3 +1,4 @@
+use std::sync::RwLock;
 use std::{collections::HashMap, fmt, sync::Arc};
 
 use chrono::{DateTime, Utc};
@@ -76,12 +77,19 @@ pub struct ConfigStore {
     configs: HashMap<Uuid, Arc<CheckConfig>>,
 }
 
+/// A RwLockable ConfigStore.
+pub type RwConfigStore = RwLock<ConfigStore>;
+
 impl ConfigStore {
     pub fn new() -> ConfigStore {
         ConfigStore {
             partitioned_buckets: HashMap::new(),
             configs: HashMap::new(),
         }
+    }
+
+    pub fn new_rw() -> RwConfigStore {
+        RwLock::new(ConfigStore::new())
     }
 
     /// Insert a new Check Configuration into the store.


### PR DESCRIPTION
Since we'll be writing from a consumer in a different thread from reading to it, we'll need some synchronization