### PR TITLE
feat: Add graceful shutdown of the scheduler via CancellationToken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3396,6 +3396,7 @@ dependencies = [
  "similar-asserts",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ sentry-kafka-schemas = "0.1.99"
 serde_with = { version = "3.8.1", features = ["chrono"] }
 rmp-serde = "1.3.0"
 serde_repr = "0.1.19"
+tokio-util = "0.7.11"
 
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }


### PR DESCRIPTION
This will actually wait for the last tick to complete before just outright exiting. This does **NOT** wait for the actual checks to complete, only scheduling of them.

In the future we can add some additional logic to make sure an entire tick completes before we fully shut down