### PR TITLE
ref(build): Remove cargo update steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /app
 
 COPY Cargo.toml .
 COPY Cargo.lock .
-RUN cargo update
 ENV RUSTFLAGS="-Ctarget-feature=-crt-static"
 ENV PKG_CONFIG_ALLOW_CROSS=1
 RUN cargo build --release && rm -rf src/
@@ -27,7 +26,6 @@ RUN cargo build --release && rm -rf src/
 # Copy the source code and run the build again. This should only compile the
 # app itself as the dependencies were already built above.
 COPY . ./
-RUN cargo update
 RUN rm target/release/deps/uptime_checker* && cargo build --release
 
 FROM alpine:3.20


### PR DESCRIPTION
This was updating packages. We don't actually want that