### PR TITLE
feat(consumer): Track 'boot' where it reads the backlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +940,17 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -989,6 +1015,7 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -3428,6 +3455,7 @@ dependencies = [
  "clap",
  "console",
  "figment",
+ "futures",
  "httpmock",
  "metrics",
  "metrics-exporter-statsd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ chrono = { version = "0.4.31", default-features = false, features = [ "std", "se
 httpmock = "0.7.0-rc.1"
 reqwest = "0.12.4"
 rust_arroyo = { version = "*", git = "https://github.com/getsentry/arroyo", rev = "0b84afc07131d8b8d48abcb7c8de8cfa2a98e526" }
-tokio = { version = "1.28.0", features = ["macros", "sync", "tracing", "signal", "rt-multi-thread"] }
+tokio = { version = "1.28.0", features = ["macros", "sync", "tracing", "signal", "rt-multi-thread", "test-util"] }
 uuid = { version = "1.8.0", features = ["serde", "v4"] }
 serde = { version = "1.0.159", features = ["derive", "rc"] }
 serde_json = "1.0.93"
@@ -31,6 +31,7 @@ serde_repr = "0.1.19"
 tokio-util = "0.7.11"
 metrics-exporter-statsd = "0.8.0"
 metrics = "0.23.0"
+futures = "0.3.30"
 
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }


### PR DESCRIPTION
This adds logic that will wait for the consumer to idle. Once the
consumer is idling we'll know we've read the backlog of configs and can
start the scheduler safely.