### PR TITLE
Refactor service per partition

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,21 +4,18 @@ pub mod cli;
 pub mod config;
 
 use clap::Parser;
-use tokio::{join, signal::ctrl_c};
-use tokio_util::sync::CancellationToken;
+use tokio::signal::ctrl_c;
 use tracing::info;
 
 use crate::{
-    config_consumer::run_config_consumer,
-    config_store::ConfigStore,
     logging::{self, LoggingConfig},
+    manager::Manager,
     metrics::{self, MetricsConfig},
-    scheduler::run_scheduler,
 };
 
 pub fn execute() -> io::Result<()> {
     let app = cli::CliApp::parse();
-    let config = config::Config::extract(&app).expect("Configuration invalid");
+    let config = Arc::new(config::Config::extract(&app).expect("Configuration invalid"));
 
     logging::init(LoggingConfig::from_config(&config));
     metrics::init(MetricsConfig::from_config(&config));
@@ -31,28 +28,12 @@ pub fn execute() -> io::Result<()> {
             .build()
             .unwrap()
             .block_on(async {
-                let config_store = Arc::new(ConfigStore::new_rw());
+                let manager = Arc::new(Manager::new(config.clone()));
 
-                let shutdown_signal = CancellationToken::new();
-
-                let (config_consumer, consumer_booting) =
-                    run_config_consumer(&config, config_store.clone(), shutdown_signal.clone());
-
-                // Wait for the config consumre to read the backlog of configs before continuing to
-                // start the scheduler. We don't want to start scheduling until we've read all the
-                // configs since we want to avoid scheduling old configs.
-                consumer_booting
-                    .await
-                    .expect("Failed to wait for consumer to boot");
-
-                let check_scheduler =
-                    run_scheduler(&config, config_store.clone(), shutdown_signal.clone());
+                manager.start(manager.clone());
 
                 ctrl_c().await.expect("Failed to listen for ctrl-c signal");
-                shutdown_signal.cancel();
-
-                // TODO(epurkhiser): Do we need to be concerned about the error results here?
-                let _ = join!(config_consumer, check_scheduler);
+                manager.shutdown().await;
 
                 Ok(())
             }),

--- a/src/config_consumer.rs
+++ b/src/config_consumer.rs
@@ -136,7 +136,7 @@ pub fn run_config_consumer(
             .expect("Failed to run config consumer");
     });
 
-    let shutdown_handle = tokio::spawn(async move {
+    tokio::spawn(async move {
         shutdown.cancelled().await;
         processing_handle.signal_shutdown();
         join_handle
@@ -144,9 +144,7 @@ pub fn run_config_consumer(
             .expect("Failed to join config consumer consumer thread");
 
         info!("Config consuemr shutdown");
-    });
-
-    shutdown_handle
+    })
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod checker;
 mod config_consumer;
 mod config_store;
 mod logging;
+mod manager;
 mod metrics;
 mod producer;
 mod scheduler;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -48,7 +48,7 @@ impl PartitionedService {
             KafkaConfig::new_config(self.config.results_kafka_cluster.to_owned(), None),
         ));
 
-        let check_scheduler = run_scheduler(
+        run_scheduler(
             self.config_store.clone(),
             checker,
             producer,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,0 +1,133 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, RwLock},
+};
+
+use rust_arroyo::backends::kafka::config::KafkaConfig;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use crate::{
+    app::config::Config,
+    checker::http_checker::HttpChecker,
+    config_consumer::run_config_consumer,
+    config_store::{ConfigStore, RwConfigStore},
+    producer::kafka_producer::KafkaResultsProducer,
+    scheduler::run_scheduler,
+};
+
+/// Represents the set of services that run per partition.
+#[derive(Debug)]
+pub struct PartitionedService {
+    partition: u16,
+    config: Arc<Config>,
+    config_store: Arc<RwConfigStore>,
+    shutdown_signal: CancellationToken,
+}
+
+impl PartitionedService {
+    fn new(config: Arc<Config>, partition: u16) -> Self {
+        Self {
+            config,
+            partition,
+            config_store: Arc::new(ConfigStore::new_rw()),
+            shutdown_signal: CancellationToken::new(),
+        }
+    }
+
+    pub fn get_config_store(&self) -> Arc<RwConfigStore> {
+        self.config_store.clone()
+    }
+
+    /// Begin scheduling checks for this partition.
+    pub fn start(&self) {
+        let checker = Arc::new(HttpChecker::new());
+
+        let producer = Arc::new(KafkaResultsProducer::new(
+            &self.config.results_kafka_topic,
+            KafkaConfig::new_config(self.config.results_kafka_cluster.to_owned(), None),
+        ));
+
+        let check_scheduler = run_scheduler(
+            self.config_store.clone(),
+            checker,
+            producer,
+            self.shutdown_signal.clone(),
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct Manager {
+    config: Arc<Config>,
+    services: RwLock<HashMap<u16, Arc<PartitionedService>>>,
+    shutdown_signal: CancellationToken,
+}
+
+impl Manager {
+    pub fn new(config: Arc<Config>) -> Self {
+        Self {
+            config,
+            services: RwLock::new(HashMap::new()),
+            shutdown_signal: CancellationToken::new(),
+        }
+    }
+
+    /// Instantiates a new manager with a single partition and a default config
+    pub fn new_simple() -> Self {
+        let config = Arc::new(Config::default());
+        let manager = Self::new(config);
+        manager.register_partition(0);
+        manager
+    }
+
+    pub fn start(&self, manager: Arc<Manager>) {
+        let _config_consumer =
+            run_config_consumer(&self.config, manager, self.shutdown_signal.clone());
+    }
+
+    pub async fn shutdown(&self) {
+        self.shutdown_signal.cancel();
+    }
+
+    pub fn get_service(&self, partition: u16) -> Arc<PartitionedService> {
+        self.services
+            .read()
+            .unwrap()
+            .get(&partition)
+            .expect("Cannot access unregistered partition")
+            .clone()
+    }
+
+    /// Notify the manager for which parititions it is responsible for.
+    ///
+    /// Partitions that were previously known will have their services dropped. New partitions will
+    /// register a new PartitionedService.
+    pub fn update_partitions(&self, new_partitions: &HashSet<u16>) {
+        let known_partitions: HashSet<_> = self.services.read().unwrap().keys().cloned().collect();
+
+        // Drop partitions that we are no longer responsible for
+        for removed_part in known_partitions.difference(new_partitions) {
+            self.unregister_partition(*removed_part);
+        }
+
+        // Add new partitions and start partition services
+        for new_partiton in new_partitions.difference(&known_partitions) {
+            self.register_partition(*new_partiton);
+            self.get_service(*new_partiton).start();
+        }
+    }
+
+    fn register_partition(&self, partition: u16) {
+        info!(partition, "Registering new partition");
+        self.services.write().unwrap().insert(
+            partition,
+            Arc::new(PartitionedService::new(self.config.clone(), partition)),
+        );
+    }
+
+    fn unregister_partition(&self, partition: u16) {
+        info!(partition, "Unregistering revoked partition");
+        self.services.write().unwrap().remove(&partition);
+    }
+}


### PR DESCRIPTION
Refactors the uptime checker to have a separate scheduler per Kafka partition. This makes assigning/revoking partitions much simpler, and allows us to more easily block while partitions are loading in the future.