### PR TITLE
fix(uptime): Prevent configs for the same subscription from duplicating

### DIFF
--- a/src/config_store.rs
+++ b/src/config_store.rs
@@ -280,32 +280,31 @@ mod tests {
     fn test_add_duplicate_config() {
         let mut store = ConfigStore::new();
 
-        let mut config = CheckConfig::default();
-        config.interval = CheckInterval::OneMinute;
-
-        let subsciption_id = config.subscription_id;
-
-        let arc_config = Arc::new(config);
-        store.add_config(arc_config.clone());
+        let config = Arc::new(CheckConfig {
+            interval: CheckInterval::OneMinute,
+            ..Default::default()
+        });
+        store.add_config(config.clone());
 
         for slot in (0..60)
             .map(|c| (60 * c))
             .collect::<Vec<_>>(){
             assert_eq!(store.partitioned_buckets[&0][slot].len(), 1);
-            assert!(store.partitioned_buckets[&0][slot].contains(&arc_config));
+            assert!(store.partitioned_buckets[&0][slot].contains(&config));
         }
 
-        let mut config = CheckConfig::default();
-        config.interval = CheckInterval::FiveMinutes;
-        let arc_config = Arc::new(config);
-        store.add_config(arc_config.clone());
+        let config = Arc::new(CheckConfig {
+            interval: CheckInterval::FiveMinutes,
+            ..Default::default()
+        });
+        store.add_config(config.clone());
 
         for slot in (0..60)
             .map(|c| (60 * c))
             .collect::<Vec<_>>(){
             if slot % 300 == 0 {
                 assert_eq!(store.partitioned_buckets[&0][slot].len(), 1);
-                assert!(store.partitioned_buckets[&0][slot].contains(&arc_config));
+                assert!(store.partitioned_buckets[&0][slot].contains(&config));
             } else{
                 assert_eq!(store.partitioned_buckets[&0][slot].len(), 0, "slot {} contained values {:#?}", slot, store.partitioned_buckets[&0][slot]);
             }

--- a/src/types/check_config.rs
+++ b/src/types/check_config.rs
@@ -1,3 +1,4 @@
+use std::hash::{Hash, Hasher};
 use chrono::TimeDelta;
 use serde::Deserialize;
 use serde_repr::Deserialize_repr;
@@ -23,7 +24,7 @@ pub const MAX_CHECK_INTERVAL_SECS: usize = CheckInterval::SixtyMinutes as usize;
 
 /// The CheckConfig represents a configuration for a single check.
 #[serde_as]
-#[derive(Debug, PartialEq, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct CheckConfig {
     /// The kafka partition this config is associated to.
     #[serde(skip)]
@@ -44,6 +45,20 @@ pub struct CheckConfig {
 
     /// The actual HTTP URL to check.
     pub url: String,
+}
+
+impl PartialEq for CheckConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.subscription_id == other.subscription_id
+    }
+}
+
+impl Eq for CheckConfig {}
+
+impl Hash for CheckConfig {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.subscription_id.hash(state);
+    }
 }
 
 impl CheckConfig {


### PR DESCRIPTION
If we have multiple values for a subscription in the config topic we will end up with duplicate subscriptions. This pr makes sure that subscriptions won't duplicate when we have an updated config in the topic.

Previously, we decided that since we will always delete/create subscriptions to update them that we didn't need to de-dupe. Due to the way that we generate test configs for the uptime checker this caused a lot of duplicates and confusion with testing. It seems safer to just guarantee that we don't get duplicates.

As well as this, the way we send updates from sentry has an at least once guarantee. So it's possible that we might send the same update more than once in certain failure scenarios. This fix will also guard against this.