### PR TITLE
chore(uptime): Remove partition from `CheckConfig`

### DIFF
--- a/src/config_consumer.rs
+++ b/src/config_consumer.rs
@@ -44,7 +44,7 @@ fn register_config(
     match broker_message.payload.payload() {
         // Register new configuration
         Some(payload) => {
-            let mut config: CheckConfig = rmp_serde::from_slice(payload).map_err(|err| {
+            let config: CheckConfig = rmp_serde::from_slice(payload).map_err(|err| {
                 error!(?err, "Failed to decode config message");
                 InvalidMessage::from(broker_message)
             })?;
@@ -53,8 +53,6 @@ fn register_config(
                 error!(?key, ?config.subscription_id, "Config key mismatch");
                 return Err(InvalidMessage::from(broker_message));
             }
-
-            config.partition = partition;
 
             // Store configuration
             debug!(config = ?config, "Consumed configuration");
@@ -205,7 +203,6 @@ mod tests {
             .all_configs();
 
         assert_eq!(configs.len(), 1);
-        assert_eq!(configs[0].partition, 0);
         assert_eq!(
             configs[0].subscription_id,
             uuid!("d7629c6c-82be-4f67-9ee7-8a0d977856d2")

--- a/src/types/check_config.rs
+++ b/src/types/check_config.rs
@@ -26,10 +26,6 @@ pub const MAX_CHECK_INTERVAL_SECS: usize = CheckInterval::SixtyMinutes as usize;
 #[serde_as]
 #[derive(Debug, Clone, Deserialize)]
 pub struct CheckConfig {
-    /// The kafka partition this config is associated to.
-    #[serde(skip)]
-    pub partition: u16,
-
     /// The subscription this check configuration is associated to in sentry.
     #[serde(with = "uuid::serde::simple")]
     pub subscription_id: Uuid,
@@ -95,7 +91,6 @@ mod tests {
     impl Default for CheckConfig {
         fn default() -> Self {
             CheckConfig {
-                partition: 0,
                 subscription_id: Uuid::from_u128(0),
                 interval: CheckInterval::OneMinute,
                 timeout: TimeDelta::seconds(10),
@@ -122,7 +117,6 @@ mod tests {
         assert_eq!(
             rmp_serde::from_slice::<CheckConfig>(&example).unwrap(),
             CheckConfig {
-                partition: 0,
                 subscription_id: uuid!("d7629c6c-82be-4f67-9ee7-8a0d977856d2"),
                 timeout: TimeDelta::milliseconds(500),
                 interval: CheckInterval::FiveMinutes,


### PR DESCRIPTION
`CheckConfig` no longer needs to be aware of which partition it was assigned to, so just removing it.