### PR TITLE
feat(uptime): Add config setting for redis cluster

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -52,6 +52,10 @@ pub struct Config {
 
     /// The topic to load [`CheckConfig`]s from.
     pub configs_kafka_topic: String,
+
+    /// The general purpose redis cluster to use with this service
+    #[serde_as(as = "serde_with::StringWithSeparator::<CommaSeparator, String>")]
+    pub redis_cluster_nodes: Vec<String>,
 }
 
 impl Default for Config {
@@ -66,6 +70,7 @@ impl Default for Config {
             results_kafka_topic: "uptime-results".to_owned(),
             configs_kafka_cluster: vec![],
             configs_kafka_topic: "uptime-configs".to_owned(),
+            redis_cluster_nodes: vec![],
         }
     }
 }
@@ -117,6 +122,7 @@ mod tests {
                 results_kafka_cluster: '10.0.0.1,10.0.0.2:9000'
                 configs_kafka_cluster: '10.0.0.1,10.0.0.2:9000'
                 statsd_addr: 10.0.0.1:8126
+                redis_cluster_nodes: '10.0.0.1:6379,10.0.0.2:6379'
                 "#,
             )?;
 
@@ -141,6 +147,7 @@ mod tests {
                     configs_kafka_cluster: vec!["10.0.0.1".to_owned(), "10.0.0.2:9000".to_owned()],
                     results_kafka_topic: "uptime-results".to_owned(),
                     configs_kafka_topic: "uptime-configs".to_owned(),
+                    redis_cluster_nodes: vec!["10.0.0.1:6379".to_owned(), "10.0.0.2:6379".to_owned()],
                 }
             );
             Ok(())
@@ -169,7 +176,10 @@ mod tests {
                 "10.0.0.1,10.0.0.2:7000",
             );
             jail.set_env("UPTIME_CHECKER_STATSD_ADDR", "10.0.0.1:1234");
-
+            jail.set_env(
+                "UPTIME_CHECKER_REDIS_CLUSTER_NODES",
+                "10.0.0.3:6379,10.0.0.2:6379",
+            );
             let app = cli::CliApp {
                 config: Some(PathBuf::from("config.yaml")),
                 log_level: Some(logging::Level::Trace),
@@ -191,6 +201,7 @@ mod tests {
                     configs_kafka_cluster: vec!["10.0.0.1".to_owned(), "10.0.0.2:7000".to_owned()],
                     results_kafka_topic: "uptime-results".to_owned(),
                     configs_kafka_topic: "uptime-configs".to_owned(),
+                    redis_cluster_nodes: vec!["10.0.0.3:6379".to_owned(), "10.0.0.2:6379".to_owned()],
                 }
             );
             Ok(())


### PR DESCRIPTION
We're going to use redis to keep track of progress on partitions, so adding config for this