### PR TITLE
fix: Run consumer in it's own thread

### DIFF
--- a/src/config_consumer.rs
+++ b/src/config_consumer.rs
@@ -11,7 +11,7 @@ use rust_arroyo::{
     types::{InnerMessage, Message, Partition, Topic},
 };
 use std::{collections::HashMap, sync::Arc};
-use tokio::task::JoinHandle;
+use tokio::task::{self, JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 use uuid::Uuid;
@@ -127,7 +127,7 @@ pub fn run_config_consumer(
 
     let mut processing_handle = stream_processor.get_handle();
 
-    let join_handle = tokio::spawn(async move {
+    let join_handle = task::spawn_blocking(|| {
         info!("Starting config consumer");
         stream_processor
             .run()


### PR DESCRIPTION
We don't want this running as a tokio task since it will block and consume an entire thread. Tokio will only have so many task executor threads so we may end up the scenario where executors are available to drive futures forward.

The reason it was run in a tokio task before was because the partitions update function in the manager would attempt to start new tokio tasks, which it could not do outside of the tokio runtime.

Instead we can use tokios `task::spawn_blocking` to run the consumer, which tokio will run in it's own blocking thread.