### PR TITLE
feat: Add metrics for each partitions "boot"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod app;
 mod checker;
 mod config_consumer;
 mod config_store;
+mod config_waiter;
 mod logging;
 mod manager;
 mod metrics;


### PR DESCRIPTION
Brings back the logic we wrote to detect when a partition has "completed" booting