### PR TITLE
feat(uptime): Store completed ticks in redis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: shogo82148/actions-setup-redis@v1
+      - uses: shogo82148/actions-setup-redis@428a144f11914412a8f52902296e134dd2e0f925
         with:
           redis-version: "7.x"
       - name: Install Rust Toolchain

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: shogo82148/actions-setup-redis@v1
+        with:
+          redis-version: "7.x"
       - name: Install Rust Toolchain
         run: rustup toolchain install stable --profile minimal --no-self-update
       - name: Run Cargo Tests
         run: cargo test
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +591,20 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -2230,6 +2250,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e902a69d09078829137b4a5d9d082e0490393537badd7c91a3d69d14639e115f"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.7",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2888,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
  "memchr",
@@ -2985,6 +3028,12 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sharded-slab"
@@ -3605,6 +3654,7 @@ dependencies = [
  "httpmock",
  "metrics",
  "metrics-exporter-statsd",
+ "redis",
  "reqwest 0.12.5",
  "rmp-serde",
  "rust_arroyo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.79"
 [dependencies]
 anyhow = "1.0.66"
 clap = { version = "4.4.6", features = ["derive"] }
-chrono = { version = "0.4.31", default-features = false, features = [ "std", "serde" ] }
+chrono = { version = "0.4.31", default-features = false, features = ["std", "serde"] }
 httpmock = "0.7.0-rc.1"
 reqwest = "0.12.4"
 rust_arroyo = { version = "*", git = "https://github.com/getsentry/arroyo", rev = "0b84afc07131d8b8d48abcb7c8de8cfa2a98e526" }
@@ -34,6 +34,7 @@ metrics-exporter-statsd = "0.8.0"
 metrics = "0.23.0"
 futures = "0.3.30"
 tokio-stream = "0.1.15"
+redis = { version = "0.26.0", features = ["tokio-comp"] }
 
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -56,9 +56,8 @@ pub struct Config {
     /// The topic to load [`CheckConfig`]s from.
     pub configs_kafka_topic: String,
 
-    /// The general purpose redis cluster to use with this service
-    #[serde_as(as = "serde_with::StringWithSeparator::<CommaSeparator, String>")]
-    pub redis_cluster_nodes: Vec<String>,
+    /// The general purpose redis node to use with this service
+    pub redis_host: String,
 }
 
 impl Default for Config {
@@ -74,7 +73,7 @@ impl Default for Config {
             results_kafka_topic: "uptime-results".to_owned(),
             configs_kafka_cluster: vec![],
             configs_kafka_topic: "uptime-configs".to_owned(),
-            redis_cluster_nodes: vec![],
+            redis_host: "redis://127.0.0.1:6379".to_owned(),
         }
     }
 }
@@ -127,7 +126,7 @@ mod tests {
                 results_kafka_cluster: '10.0.0.1,10.0.0.2:9000'
                 configs_kafka_cluster: '10.0.0.1,10.0.0.2:9000'
                 statsd_addr: 10.0.0.1:8126
-                redis_cluster_nodes: '10.0.0.1:6379,10.0.0.2:6379'
+                redis_host: redis://127.0.0.1:6379
                 "#,
             )?;
 
@@ -153,10 +152,7 @@ mod tests {
                     configs_kafka_cluster: vec!["10.0.0.1".to_owned(), "10.0.0.2:9000".to_owned()],
                     results_kafka_topic: "uptime-results".to_owned(),
                     configs_kafka_topic: "uptime-configs".to_owned(),
-                    redis_cluster_nodes: vec![
-                        "10.0.0.1:6379".to_owned(),
-                        "10.0.0.2:6379".to_owned()
-                    ],
+                    redis_host: "redis://127.0.0.1:6379".to_owned(),
                 }
             );
             Ok(())
@@ -185,10 +181,7 @@ mod tests {
                 "10.0.0.1,10.0.0.2:7000",
             );
             jail.set_env("UPTIME_CHECKER_STATSD_ADDR", "10.0.0.1:1234");
-            jail.set_env(
-                "UPTIME_CHECKER_REDIS_CLUSTER_NODES",
-                "10.0.0.3:6379,10.0.0.2:6379",
-            );
+            jail.set_env("UPTIME_CHECKER_REDIS_HOST", "10.0.0.3:6379");
             let app = cli::CliApp {
                 config: Some(PathBuf::from("config.yaml")),
                 log_level: Some(logging::Level::Trace),
@@ -211,10 +204,7 @@ mod tests {
                     configs_kafka_cluster: vec!["10.0.0.1".to_owned(), "10.0.0.2:7000".to_owned()],
                     results_kafka_topic: "uptime-results".to_owned(),
                     configs_kafka_topic: "uptime-configs".to_owned(),
-                    redis_cluster_nodes: vec![
-                        "10.0.0.3:6379".to_owned(),
-                        "10.0.0.2:6379".to_owned()
-                    ],
+                    redis_host: "10.0.0.3:6379".to_owned(),
                 }
             );
             Ok(())

--- a/src/config_store.rs
+++ b/src/config_store.rs
@@ -1,10 +1,10 @@
+use crate::types::check_config::{CheckConfig, MAX_CHECK_INTERVAL_SECS};
 use chrono::{DateTime, Utc};
 use std::collections::HashSet;
 use std::sync::RwLock;
 use std::{collections::HashMap, fmt, sync::Arc};
 use tokio::time::Instant;
 use uuid::Uuid;
-use crate::types::check_config::{CheckConfig, MAX_CHECK_INTERVAL_SECS};
 
 // Represents a bucket of checks at a given tick.
 pub type TickBucket = HashSet<Arc<CheckConfig>>;

--- a/src/config_store.rs
+++ b/src/config_store.rs
@@ -4,7 +4,6 @@ use std::sync::RwLock;
 use std::{collections::HashMap, fmt, sync::Arc};
 use tokio::time::Instant;
 use uuid::Uuid;
-
 use crate::types::check_config::{CheckConfig, MAX_CHECK_INTERVAL_SECS};
 
 // Represents a bucket of checks at a given tick.

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -30,6 +30,10 @@ pub struct PartitionedService {
     scheduler_join_handle: JoinHandle<()>,
 }
 
+pub fn build_progress_key(partition: u16) -> String {
+    format!("scheduler_process::{}", partition).to_string()
+}
+
 impl PartitionedService {
     pub fn start(config: Arc<Config>, executor_sender: CheckSender, partition: u16) -> Self {
         let config_store = Arc::new(ConfigStore::new_rw());
@@ -47,6 +51,8 @@ impl PartitionedService {
             config_store.clone(),
             executor_sender,
             shutdown_signal.clone(),
+            build_progress_key(partition),
+            config.redis_host.clone(),
         );
 
         Self {

--- a/src/producer/dummy_producer.rs
+++ b/src/producer/dummy_producer.rs
@@ -8,7 +8,7 @@ pub struct DummyResultsProducer {
 
 impl DummyResultsProducer {
     pub fn new(_topic_name: &str) -> Self {
-        let schema = sentry_kafka_schemas::get_schema("uptime-results", None).unwrap();
+        let schema = sentry_kafka_schemas::get_schema(_topic_name, None).unwrap();
         Self { schema }
     }
 }

--- a/src/producer/dummy_producer.rs
+++ b/src/producer/dummy_producer.rs
@@ -7,8 +7,8 @@ pub struct DummyResultsProducer {
 }
 
 impl DummyResultsProducer {
-    pub fn new(_topic_name: &str) -> Self {
-        let schema = sentry_kafka_schemas::get_schema(_topic_name, None).unwrap();
+    pub fn new(topic_name: &str) -> Self {
+        let schema = sentry_kafka_schemas::get_schema(topic_name, None).unwrap();
         Self { schema }
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,33 +1,71 @@
+use chrono::{DurationRound, TimeDelta, TimeZone, Utc};
 use std::sync::Arc;
 
-use chrono::Utc;
 use tokio::sync::mpsc;
+
+use std::time::Duration;
 use tokio::task::JoinHandle;
-use tokio::time::{self, Instant};
+use tokio::time::{interval, Instant};
+
 use tokio_util::sync::CancellationToken;
 
 use crate::check_executor::{queue_check, CheckSender};
 use crate::config_store::{RwConfigStore, Tick};
+use redis::{AsyncCommands, Client};
 
 pub fn run_scheduler(
     partition: u16,
     config_store: Arc<RwConfigStore>,
     executor_sender: CheckSender,
     shutdown: CancellationToken,
+    progress_key: String,
+    redis_host: String,
 ) -> JoinHandle<()> {
     tracing::info!(partition, "scheduler.starting");
-    tokio::spawn(async move { scheduler_loop(config_store, executor_sender, shutdown).await })
+    tokio::spawn(async move {
+        scheduler_loop(
+            config_store,
+            executor_sender,
+            shutdown,
+            progress_key,
+            redis_host,
+        )
+        .await
+    })
 }
 
 async fn scheduler_loop(
     config_store: Arc<RwConfigStore>,
     executor_sender: CheckSender,
     shutdown: CancellationToken,
+    progress_key: String,
+    redis_host: String,
 ) {
-    let mut interval = time::interval(time::Duration::from_secs(1));
+    let client = Client::open(redis_host.clone()).unwrap();
+    let mut connection = client
+        .get_multiplexed_tokio_connection()
+        .await
+        .expect("Unable to connect to Redis");
+    let result: Option<String> = connection
+        .get(&progress_key)
+        .await
+        .expect("Unable to get last tick key");
+    let tick_frequency = Duration::from_secs(1);
+    tracing::debug!(progress_key, result, "scheduler.redis_stored_tick_value");
+    let start = match result {
+        Some(result) => {
+            let nanos: i64 = result.parse().unwrap_or(Utc::now().timestamp());
+            Utc.timestamp_nanos(nanos) + tick_frequency
+        }
+        None => Utc::now().duration_trunc(TimeDelta::seconds(1)).unwrap(),
+    };
+    tracing::info!(%start, "scheduler.starting_at");
 
-    let start = Utc::now();
-    let instant = Instant::now();
+    let instant = Instant::now()
+        .checked_sub((Utc::now() - start).to_std().unwrap())
+        .unwrap();
+    let mut interval = interval(tick_frequency);
+    interval.reset_at(instant);
 
     let (tick_complete_tx, mut tick_complete_rx) = mpsc::unbounded_channel();
 
@@ -80,12 +118,21 @@ async fn scheduler_loop(
         while let Some(tick_complete_join_handle) = tick_complete_rx.recv().await {
             // XXX: This task guarantees that we can process ticks IN ORDER upon tick execution.
             // This waits for the tick to complete before waiting on the next tick to complete.
+            tracing::debug!("scheduler.tick_awaiting_join_handle");
             let tick = tick_complete_join_handle
                 .await
                 .expect("Failed to recieve completed tick");
 
+            let progress = tick.time().timestamp_nanos_opt().unwrap();
+            tracing::debug!(tick = %tick, progress, "scheduler.tick_complete_join_handle");
+
+            let _: () = connection
+                .set(&progress_key, progress.to_string())
+                .await
+                .expect("Couldn't save progress of scheduler");
             tracing::debug!(tick = %tick, "scheduler.tick_execution_complete_in_order");
         }
+        tracing::debug!("scheduler.tick_complete_join_handle_finished")
     });
 
     while !shutdown.is_cancelled() {
@@ -93,25 +140,29 @@ async fn scheduler_loop(
         let tick = Tick::from_time(start + interval_tick.duration_since(instant));
         schedule_checks(tick);
     }
+    tracing::info!("scheduler.begin_shutdown");
 
     // Wait for all dispatch ticks to have completed
     drop(tick_complete_tx);
-    in_order_tick_processor_join_handle.await.unwrap();
-
+    let _ = in_order_tick_processor_join_handle.await;
     tracing::info!("scheduler.shutdown");
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
+    use crate::app::config::Config;
     use chrono::{Duration, Utc};
+    use redis::{Client, Commands};
     use similar_asserts::assert_eq;
+    use std::sync::Arc;
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
     use tracing_test::traced_test;
     use uuid::Uuid;
 
+    use super::run_scheduler;
+
+    use crate::manager::build_progress_key;
     use crate::{
         config_store::ConfigStore,
         types::{
@@ -120,11 +171,20 @@ mod tests {
         },
     };
 
-    use super::run_scheduler;
-
-    #[tokio::test(start_paused = true)]
     #[traced_test]
+    #[tokio::test(start_paused = true)]
     async fn test_scheduler() {
+        let config = Config::default();
+        let partition = 0;
+
+        let progress_key = build_progress_key(partition);
+        let client = Client::open(config.redis_host.clone()).unwrap();
+        let mut connection = client.get_connection().expect("Unable to connect to Redis");
+        let _: () = connection
+            .set(progress_key.clone(), 0)
+            .expect("Couldn't save progress of scheduler");
+
+
         let config_store = Arc::new(ConfigStore::new_rw());
 
         let config1 = Arc::new(CheckConfig {
@@ -145,9 +205,16 @@ mod tests {
         let (executor_tx, mut executor_rx) = mpsc::unbounded_channel();
         let shutdown_token = CancellationToken::new();
 
-        let join_handle = run_scheduler(0, config_store, executor_tx, shutdown_token.clone());
+        let join_handle = run_scheduler(
+            partition,
+            config_store,
+            executor_tx,
+            shutdown_token.clone(),
+            build_progress_key(0),
+            config.redis_host.clone(),
+        );
 
-        // Wait and execute both ticks
+        // // Wait and execute both ticks
         let scheduled_check1 = executor_rx.recv().await.unwrap();
         let scheduled_check1_time = scheduled_check1.get_tick().time();
         assert_eq!(scheduled_check1.get_config().clone(), config1);
@@ -189,9 +256,110 @@ mod tests {
             request_info: None,
         });
 
+        shutdown_token.cancel();
+        // XXX: Without this loop we end up stuck forever, we should try to understand that better
+        while executor_rx.recv().await.is_some() {}
+        join_handle.await.unwrap();
         assert!(logs_contain("scheduler.tick_execution_complete_in_order"));
+        let progress: u64 = connection
+            .get(progress_key)
+            .expect("Couldn't save progress of scheduler");
+        assert_eq!(progress, 60000000000);
+    }
+
+    #[traced_test]
+    #[tokio::test(start_paused = true)]
+    async fn test_scheduler_start() {
+        // TODO: Better abstraction here
+        let config = Config::default();
+        let partition = 1;
+
+        let progress_key = build_progress_key(partition);
+        let client = Client::open(config.redis_host.clone()).unwrap();
+        let mut connection = client.get_connection().expect("Unable to connect to Redis");
+        let _: () = connection
+            .set(progress_key.clone(), std::time::Duration::from_secs(2).as_nanos().to_string())
+            .expect("Couldn't save progress of scheduler");
+
+        let config_store = Arc::new(ConfigStore::new_rw());
+
+        let config1 = Arc::new(CheckConfig {
+            subscription_id: Uuid::from_u128(1),
+            ..Default::default()
+        });
+        let config2 = Arc::new(CheckConfig {
+            subscription_id: Uuid::from_u128(3),
+            ..Default::default()
+        });
+
+        {
+            let mut rw_store = config_store.write().unwrap();
+            rw_store.add_config(config1.clone());
+            rw_store.add_config(config2.clone());
+        }
+
+        let (executor_tx, mut executor_rx) = mpsc::unbounded_channel();
+        let shutdown_token = CancellationToken::new();
+
+        let join_handle = run_scheduler(
+            partition,
+            config_store,
+            executor_tx,
+            shutdown_token.clone(),
+            progress_key.clone(),
+            config.redis_host.clone(),
+        );
+
+        // // Wait and execute both ticks
+        let scheduled_check1 = executor_rx.recv().await.unwrap();
+        let scheduled_check1_time = scheduled_check1.get_tick().time();
+        assert_eq!(scheduled_check1.get_config().clone(), config2);
+
+        let scheduled_check2 = executor_rx.recv().await.unwrap();
+        let scheduled_check2_time = scheduled_check2.get_tick().time();
+        assert_eq!(scheduled_check2.get_config().clone(), config1);
+
+        // The second tick should have been scheduled 58 seconds after the first tick since it is
+        // 58 buckets after the first tick.
+        assert_eq!(
+            scheduled_check2_time - scheduled_check1_time,
+            Duration::seconds(58)
+        );
+
+        // Record results for both to complete both ticks
+        scheduled_check1.record_result(CheckResult {
+            guid: Uuid::new_v4(),
+            subscription_id: config2.subscription_id,
+            status: CheckStatus::Success,
+            status_reason: None,
+            trace_id: Default::default(),
+            span_id: Default::default(),
+            scheduled_check_time: scheduled_check1_time,
+            actual_check_time: Utc::now(),
+            duration: Some(Duration::seconds(1)),
+            request_info: None,
+        });
+        scheduled_check2.record_result(CheckResult {
+            guid: Uuid::new_v4(),
+            subscription_id: config1.subscription_id,
+            status: CheckStatus::Success,
+            status_reason: None,
+            trace_id: Default::default(),
+            span_id: Default::default(),
+            scheduled_check_time: scheduled_check2_time,
+            actual_check_time: Utc::now(),
+            duration: Some(Duration::seconds(1)),
+            request_info: None,
+        });
 
         shutdown_token.cancel();
+        // XXX: Without this loop we end up stuck forever, we should try to understand that better
+        while executor_rx.recv().await.is_some() {}
         join_handle.await.unwrap();
+        assert!(logs_contain("scheduler.tick_execution_complete_in_order"));
+        let progress: u64 = connection
+            .get(progress_key)
+            .expect("Couldn't save progress of scheduler");
+        assert_eq!(progress, 62000000000);
     }
 }


### PR DESCRIPTION
This stores tick progress in Redis and loads it when the scheduler starts up. We use this to set the instance that we start from, so that we won't miss ticks during deploys, rebalances and crashes.

We store the ticks as nanos and use them to reset the Interval back in time. We store the completed ticks in `in_order_tick_processor_join_handle`, which gives us a guaranteed in-order completion of ticks, so that we know we're not missing anything.
@wedamija
