### PR TITLE
ref: Prefix logging calls with `tracing::`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,6 @@ pub mod config;
 
 use clap::Parser;
 use tokio::signal::ctrl_c;
-use tracing::info;
 
 use crate::{
     logging::{self, LoggingConfig},
@@ -20,7 +19,7 @@ pub fn execute() -> io::Result<()> {
     logging::init(LoggingConfig::from_config(&config));
     metrics::init(MetricsConfig::from_config(&config));
 
-    info!(config = ?config);
+    tracing::info!(config = ?config);
 
     match app.command {
         cli::Commands::Run => tokio::runtime::Builder::new_multi_thread()
@@ -31,13 +30,13 @@ pub fn execute() -> io::Result<()> {
                 let manager = Arc::new(Manager::new(config.clone()));
 
                 let shutdown = manager.start();
-                info!("Manager started");
+                tracing::info!("Manager started");
 
                 ctrl_c().await.expect("Failed to listen for SIGINT signal");
 
-                info!("Got SIGINT. Shutting down");
+                tracing::info!("Got SIGINT. Shutting down");
                 shutdown().await;
-                info!("Shut down complete");
+                tracing::info!("Shut down complete");
 
                 Ok(())
             }),

--- a/src/config_consumer.rs
+++ b/src/config_consumer.rs
@@ -13,7 +13,6 @@ use rust_arroyo::{
 use std::{collections::HashMap, sync::Arc};
 use tokio::task::{self, JoinHandle};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info};
 use uuid::Uuid;
 
 use crate::{app::config::Config, manager::Manager, types::check_config::CheckConfig};
@@ -30,11 +29,11 @@ fn register_config(
     let partition = broker_message.partition.index;
 
     let key = broker_message.payload.key().ok_or_else(|| {
-        error!("Missing message key (subscription_id)");
+        tracing::error!("Missing message key (subscription_id)");
         InvalidMessage::from(broker_message)
     })?;
     let subscription_id = Uuid::from_slice(key).map_err(|err| {
-        error!(?err, got_key = ?key, "Key must be a valid subscription_id UUID.");
+        tracing::error!(?err, got_key = ?key, "Key must be a valid subscription_id UUID.");
         InvalidMessage::from(broker_message)
     })?;
 
@@ -45,17 +44,17 @@ fn register_config(
         // Register new configuration
         Some(payload) => {
             let config: CheckConfig = rmp_serde::from_slice(payload).map_err(|err| {
-                error!(?err, "Failed to decode config message");
+                tracing::error!(?err, "Failed to decode config message");
                 InvalidMessage::from(broker_message)
             })?;
 
             if config.subscription_id != subscription_id {
-                error!(?key, ?config.subscription_id, "Config key mismatch");
+                tracing::error!(?key, ?config.subscription_id, "Config key mismatch");
                 return Err(InvalidMessage::from(broker_message));
             }
 
             // Store configuration
-            debug!(config = ?config, "Consumed configuration");
+            tracing::debug!(config = ?config, "Consumed configuration");
             manager
                 .get_service(partition)
                 .get_config_store()
@@ -71,7 +70,7 @@ fn register_config(
                 .write()
                 .expect("Lock poisoned")
                 .remove_config(subscription_id);
-            debug!(%subscription_id, "Removed configuration");
+            tracing::debug!(%subscription_id, "Removed configuration");
         }
     }
 
@@ -84,7 +83,7 @@ struct ConfigConsumerFactory {
 
 impl ProcessingStrategyFactory<KafkaPayload> for ConfigConsumerFactory {
     fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
-        info!("Creating ConfigConsumerFactory strategy");
+        tracing::info!("Creating ConfigConsumerFactory strategy");
         let manager = self.manager.clone();
 
         Box::new(RunTask::new(
@@ -128,7 +127,7 @@ pub fn run_config_consumer(
     let mut processing_handle = stream_processor.get_handle();
 
     let join_handle = task::spawn_blocking(|| {
-        info!("Starting config consumer");
+        tracing::info!("Starting config consumer");
         stream_processor
             .run()
             .expect("Failed to run config consumer");
@@ -136,13 +135,13 @@ pub fn run_config_consumer(
 
     tokio::spawn(async move {
         shutdown.cancelled().await;
-        info!("Shutting down config consumer");
+        tracing::info!("Shutting down config consumer");
         processing_handle.signal_shutdown();
         join_handle
             .await
             .expect("Failed to join config consumer consumer thread");
 
-        info!("Config consumer shutdown");
+        tracing::info!("Config consumer shutdown");
     })
 }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -7,7 +7,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
 
 use crate::config_waiter::wait_for_partition_boot;
 use crate::{
@@ -145,11 +144,11 @@ impl Manager {
     }
 
     fn register_partition(&self, partition: u16) {
-        info!(partition, "Registering new partition: {}", partition);
+        tracing::info!(partition, "Registering new partition: {}", partition);
         let mut services = self.services.write().unwrap();
 
         let Vacant(entry) = services.entry(partition) else {
-            error!(
+            tracing::error!(
                 "Attempted to register already registered partition: {}",
                 partition
             );
@@ -161,11 +160,11 @@ impl Manager {
     }
 
     fn unregister_partition(&self, partition: u16) {
-        info!(partition, "Unregistering revoked partition: {}", partition);
+        tracing::info!(partition, "Unregistering revoked partition: {}", partition);
         let mut services = self.services.write().unwrap();
 
         let Some(service) = services.remove(&partition) else {
-            error!(
+            tracing::error!(
                 "Attempted to unregister a partition that is not registered: {}",
                 partition
             );


### PR DESCRIPTION
Just a little bit of consistency, though no way to enforce this so 🤷‍♂️ 