### PR TITLE
ref: Add get_partition

### DIFF
--- a/src/config_consumer.rs
+++ b/src/config_consumer.rs
@@ -264,7 +264,7 @@ mod tests {
             0,
         );
         factory.update_partitions(&partitions);
-        assert_eq!(factory.manager.get_service(0).partition, 0);
+        assert_eq!(factory.manager.get_service(0).get_partition(), 0);
         partitions.remove(&Partition {
             index: 0,
             topic: Topic::new("uptime-configs"),
@@ -280,6 +280,6 @@ mod tests {
         // TODO: Not sure this is the best way to handle this?
         let result = std::panic::catch_unwind(|| factory.manager.get_service(0));
         assert!(result.is_err());
-        assert_eq!(factory.manager.get_service(1).partition, 1);
+        assert_eq!(factory.manager.get_service(1).get_partition(), 1);
     }
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -21,7 +21,7 @@ use crate::{
 /// Represents the set of services that run per partition.
 #[derive(Debug)]
 pub struct PartitionedService {
-    pub partition: u16,
+    partition: u16,
     config: Arc<Config>,
     config_store: Arc<RwConfigStore>,
     shutdown_signal: CancellationToken,
@@ -66,6 +66,10 @@ impl PartitionedService {
             self.shutdown_signal.clone(),
         );
         self.shutdown_signal.clone()
+    }
+
+    pub fn get_partition(&self) -> u16 {
+        self.partition
     }
 
     pub fn stop(&self) {


### PR DESCRIPTION
There's no reason this field should be mutated so use a getter instead