### PR TITLE
ref: Avoid stop / start state in Manager / PartitionedService

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -27,9 +27,7 @@ pub fn execute() -> io::Result<()> {
             .build()
             .unwrap()
             .block_on(async {
-                let manager = Arc::new(Manager::new(config.clone()));
-
-                let shutdown = manager.start();
+                let shutdown = Manager::start(config);
                 tracing::info!("system.manager_started");
 
                 ctrl_c().await.expect("Failed to listen for SIGINT signal");

--- a/src/config_consumer.rs
+++ b/src/config_consumer.rs
@@ -164,7 +164,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_config_store() {
-        let manager = Arc::new(Manager::new_simple());
+        let manager = Manager::start_without_consumer(Arc::new(Config::default()));
+        manager.update_partitions(&vec![0u16].into_iter().collect());
 
         // Example msgpack taken from
         // sentry-kafka-schemas/examples/uptime-configs/1/example.msgpack
@@ -210,7 +211,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_drop_config() {
-        let manager = Arc::new(Manager::new_simple());
+        let manager = Manager::start_without_consumer(Arc::new(Config::default()));
+        manager.update_partitions(&vec![0u16].into_iter().collect());
 
         let example_config = Arc::new(CheckConfig::default());
         manager
@@ -252,8 +254,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_partition() {
-        let config = Arc::new(Config::default());
-        let manager = Arc::new(Manager::new(config.clone()));
+        let manager = Manager::start_without_consumer(Arc::new(Config::default()));
         let factory = ConfigConsumerFactory { manager };
         let mut partitions: HashMap<Partition, u64> = HashMap::new();
         partitions.insert(


### PR DESCRIPTION
Instead of the manager having "stopped" and "started" state, this makes it so you may ONLY create a manager that is started.

Same for the PartitionedService.

This also makes it easier in the future now to wait for partitioned services to fully stop before the finishing manager shutdown.