### PR TITLE
feat: Add check_executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,6 +3311,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3606,6 +3617,7 @@ dependencies = [
  "similar-asserts",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tokio-util = "0.7.11"
 metrics-exporter-statsd = "0.8.0"
 metrics = "0.23.0"
 futures = "0.3.30"
+tokio-stream = "0.1.15"
 
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }

--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -1,0 +1,243 @@
+use std::sync::Arc;
+
+use futures::StreamExt;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::sync::oneshot::{self, Receiver, Sender};
+use tokio::task::JoinHandle;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+use crate::checker::Checker;
+use crate::config_store::Tick;
+use crate::producer::ResultsProducer;
+use crate::types::check_config::CheckConfig;
+use crate::types::result::{CheckResult, CheckStatus, CheckStatusReasonType};
+
+#[derive(Debug)]
+pub struct ScheduledCheck {
+    tick: Tick,
+    config: Arc<CheckConfig>,
+    resolve_tx: Sender<CheckResult>,
+}
+
+pub type CheckSender = UnboundedSender<ScheduledCheck>;
+
+pub fn run_executor(
+    concurrency: usize,
+    checker: Arc<impl Checker + 'static>,
+    producer: Arc<impl ResultsProducer + 'static>,
+) -> (CheckSender, JoinHandle<()>) {
+    tracing::info!("Starting check executor");
+
+    let (sender, reciever) = mpsc::unbounded_channel();
+    let executor =
+        tokio::spawn(async move { executor_loop(concurrency, checker, producer, reciever).await });
+
+    (sender, executor)
+}
+
+pub fn queue_check(
+    sender: &CheckSender,
+    tick: Tick,
+    config: Arc<CheckConfig>,
+) -> Receiver<CheckResult> {
+    let (resolve_tx, resolve_rx) = oneshot::channel();
+
+    let scheduled_check = ScheduledCheck {
+        tick,
+        config,
+        resolve_tx,
+    };
+    sender
+        .send(scheduled_check)
+        .expect("Failed to queue ScheduledCheck");
+
+    resolve_rx
+}
+
+async fn executor_loop(
+    concurrency: usize,
+    checker: Arc<impl Checker + 'static>,
+    producer: Arc<impl ResultsProducer + 'static>,
+    reciever: UnboundedReceiver<ScheduledCheck>,
+) {
+    let schedule_check_stream: UnboundedReceiverStream<_> = reciever.into();
+
+    schedule_check_stream
+        .for_each_concurrent(concurrency, |scheduled_check| {
+            let job_checker = checker.clone();
+            let job_producer = producer.clone();
+
+            // TODO(epurkhiser): Record metrics on the size of the size of the queue
+
+            // TODO(epurkhiser): If we're past the check deadline for a check (eg, it's past when
+            // it was scheduled + it's interval) then report the check as missed.
+
+            async move {
+                let ScheduledCheck {
+                    config,
+                    tick,
+                    resolve_tx,
+                } = scheduled_check;
+
+                let _ = tokio::spawn(async move {
+                    let check_result = job_checker.check_url(&config, &tick).await;
+
+                    if let Err(e) = job_producer.produce_checker_result(&check_result) {
+                        tracing::error!(error = ?e, "executor.failed_to_produce");
+                    }
+
+                    record_result_metrics(&check_result);
+                    tracing::info!(result = ?check_result, "executor.check_complete");
+
+                    resolve_tx
+                        .send(check_result)
+                        .expect("Failed to resolve completed check");
+                })
+                .await;
+            }
+        })
+        .await;
+}
+
+fn record_result_metrics(result: &CheckResult) {
+    // Record metrics
+    let CheckResult {
+        status,
+        scheduled_check_time,
+        actual_check_time,
+        duration,
+        status_reason,
+        ..
+    } = result;
+
+    let status_label = match status {
+        CheckStatus::Success => "success",
+        CheckStatus::Failure => "failure",
+        CheckStatus::MissedWindow => "missed_window",
+    };
+    let failure_reason = match status_reason.as_ref().map(|r| r.status_type) {
+        Some(CheckStatusReasonType::Failure) => Some("failure"),
+        Some(CheckStatusReasonType::DnsError) => Some("dns_error"),
+        Some(CheckStatusReasonType::Timeout) => Some("timeout"),
+        None => None,
+    };
+
+    // Record duration of check
+    if let Some(duration) = duration {
+        metrics::histogram!(
+            "check_result.duration_ms",
+            "histogram" => "timer",
+            "status" => status_label,
+            "failure_reason" => failure_reason.unwrap_or("ok"),
+        )
+        .record(duration.num_milliseconds() as f64);
+    }
+
+    // Record time between scheduled and actual check
+    metrics::histogram!(
+        "check_result.delay_ms",
+        "histogram" => "timer",
+        "status" => status_label,
+        "failure_reason" => failure_reason.unwrap_or("ok"),
+    )
+    .record((*actual_check_time - *scheduled_check_time).num_milliseconds() as f64);
+
+    // Record status of the check
+    metrics::counter!(
+        "check_result.processed",
+        "status" => status_label,
+        "failure_reason" => failure_reason.unwrap_or("ok"),
+    )
+    .increment(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{task::Poll, time::Duration};
+
+    use chrono::Utc;
+    use futures::poll;
+    use similar_asserts::assert_eq;
+    use tokio::{sync::oneshot::Receiver, time};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::{
+        checker::dummy_checker::DummyChecker, producer::dummy_producer::DummyResultsProducer,
+    };
+
+    #[tokio::test(start_paused = true)]
+    async fn test_executor_simple() {
+        let checker = Arc::new(DummyChecker::new(Duration::from_secs(1)));
+        let producer = Arc::new(DummyResultsProducer::new("uptime-results"));
+
+        let (sender, _) = run_executor(1, checker, producer);
+
+        let tick = Tick::from_time(Utc::now());
+        let config = Arc::new(CheckConfig {
+            subscription_id: Uuid::from_u128(1),
+            ..Default::default()
+        });
+
+        let resolve_rx = queue_check(&sender, tick, config.clone());
+        tokio::pin!(resolve_rx);
+
+        // Will not be resolved yet
+        time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(poll!(resolve_rx.as_mut()), Poll::Pending);
+
+        let result = resolve_rx.await.unwrap();
+        assert_eq!(result.subscription_id, config.subscription_id);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_executor_concurrent_limit() {
+        let checker = Arc::new(DummyChecker::new(Duration::from_secs(1)));
+        let producer = Arc::new(DummyResultsProducer::new("uptime-results"));
+
+        // Only allow 2 configs to execute concurrently
+        let (sender, _) = run_executor(2, checker, producer);
+
+        // Send 4 configs into the executor
+        let mut configs: Vec<Receiver<CheckResult>> = (0..4)
+            .map(|i| {
+                let tick = Tick::from_time(Utc::now());
+                let config = Arc::new(CheckConfig {
+                    subscription_id: Uuid::from_u128(i),
+                    ..Default::default()
+                });
+                queue_check(&sender, tick, config)
+            })
+            .collect();
+
+        let resolve_rx_4 = configs.pop().unwrap();
+        tokio::pin!(resolve_rx_4);
+
+        let resolve_rx_3 = configs.pop().unwrap();
+        tokio::pin!(resolve_rx_3);
+
+        let resolve_rx_2 = configs.pop().unwrap();
+        tokio::pin!(resolve_rx_2);
+
+        let resolve_rx_1 = configs.pop().unwrap();
+        tokio::pin!(resolve_rx_1);
+
+        // No task has completed yet
+        assert_eq!(poll!(resolve_rx_1.as_mut()), Poll::Pending);
+        assert_eq!(poll!(resolve_rx_2.as_mut()), Poll::Pending);
+        assert_eq!(poll!(resolve_rx_3.as_mut()), Poll::Pending);
+        assert_eq!(poll!(resolve_rx_4.as_mut()), Poll::Pending);
+
+        // Move time forward one second. The first two will complete, but the last two will not yet
+        time::sleep(Duration::from_millis(1001)).await;
+        assert!(matches!(poll!(resolve_rx_1.as_mut()), Poll::Ready(_)));
+        assert!(matches!(poll!(resolve_rx_2.as_mut()), Poll::Ready(_)));
+        assert_eq!(poll!(resolve_rx_3.as_mut()), Poll::Pending);
+        assert_eq!(poll!(resolve_rx_4.as_mut()), Poll::Pending);
+
+        // Move forward another second, the last two tasks should now be complete
+        time::sleep(Duration::from_millis(1001)).await;
+        assert!(matches!(poll!(resolve_rx_3.as_mut()), Poll::Ready(_)));
+        assert!(matches!(poll!(resolve_rx_4.as_mut()), Poll::Ready(_)));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 // TODO: We might want to remove this once more stable, but it's just noisy for now.
 #![allow(dead_code)]
 mod app;
+mod check_executor;
 mod checker;
 mod config_consumer;
 mod config_store;

--- a/src/types/result.rs
+++ b/src/types/result.rs
@@ -39,7 +39,7 @@ pub enum RequestType {
 }
 
 /// Captures the reason for a check's given status
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct CheckStatusReason {
     /// The type of the status reason
@@ -50,7 +50,7 @@ pub struct CheckStatusReason {
     pub description: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct RequestInfo {
     /// The type of HTTP method used for the check
@@ -62,7 +62,7 @@ pub struct RequestInfo {
 }
 
 #[serde_as]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct CheckResult {
     /// Unique identifier of the uptime check


### PR DESCRIPTION
This adds a new async task that reads from an unbounded mpsc channel and executes checks, firing the oneshot channel when complete.

This will be used in place of the scheduler actually firing off the http checker tasks