### PR TITLE
ref: Add has_service to manager

### DIFF
--- a/src/config_consumer.rs
+++ b/src/config_consumer.rs
@@ -277,9 +277,7 @@ mod tests {
             1,
         );
         factory.update_partitions(&partitions);
-        // TODO: Not sure this is the best way to handle this?
-        let result = std::panic::catch_unwind(|| factory.manager.get_service(0));
-        assert!(result.is_err());
-        assert_eq!(factory.manager.get_service(1).get_partition(), 1);
+        assert!(!factory.manager.has_service(0));
+        assert!(factory.manager.has_service(1));
     }
 }


### PR DESCRIPTION
This is mostly helpful in testing so we don't have to use catch_unwind,
which is problematic when the manager contains types that are not
`UnwindSafe` [^1]

[^1]: https://github.com/rust-lang/rfcs/blob/master/text/1236-stabilize-catch-panic.md