### PR TITLE
feat: Connect scheduler to check_executor

### DIFF
--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -19,6 +19,18 @@ pub struct ScheduledCheck {
     resolve_tx: Sender<CheckResult>,
 }
 
+impl ScheduledCheck {
+    /// Get the scheduled CheckConfig.
+    pub fn get_config(&self) -> &Arc<CheckConfig> {
+        &self.config
+    }
+
+    /// Get the tick this check was scheduled at.
+    pub fn get_tick(&self) -> &Tick {
+        &self.tick
+    }
+}
+
 pub type CheckSender = UnboundedSender<ScheduledCheck>;
 
 pub fn run_executor(

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,82 +1,26 @@
 use std::sync::Arc;
 
 use chrono::Utc;
-use tokio::task::{JoinHandle, JoinSet};
+use tokio::task::JoinHandle;
 use tokio::time::{self, Instant};
 use tokio_util::sync::CancellationToken;
 
-use crate::checker::Checker;
+use crate::check_executor::{queue_check, CheckSender};
 use crate::config_store::{RwConfigStore, Tick};
-use crate::producer::ResultsProducer;
-use crate::types::result::{CheckResult, CheckStatus, CheckStatusReasonType};
 
 pub fn run_scheduler(
     partition: u16,
     config_store: Arc<RwConfigStore>,
-    checker: Arc<impl Checker + 'static>,
-    producer: Arc<impl ResultsProducer + 'static>,
+    executor_sender: CheckSender,
     shutdown: CancellationToken,
 ) -> JoinHandle<()> {
     tracing::info!(partition, "scheduler.starting");
-    tokio::spawn(async move { scheduler_loop(config_store, checker, producer, shutdown).await })
-}
-
-fn record_result_metrics(result: &CheckResult) {
-    // Record metrics
-    let CheckResult {
-        status,
-        scheduled_check_time,
-        actual_check_time,
-        duration,
-        status_reason,
-        ..
-    } = result;
-
-    let status_label = match status {
-        CheckStatus::Success => "success",
-        CheckStatus::Failure => "failure",
-        CheckStatus::MissedWindow => "missed_window",
-    };
-    let failure_reason = match status_reason.as_ref().map(|r| r.status_type) {
-        Some(CheckStatusReasonType::Failure) => Some("failure"),
-        Some(CheckStatusReasonType::DnsError) => Some("dns_error"),
-        Some(CheckStatusReasonType::Timeout) => Some("timeout"),
-        None => None,
-    };
-
-    // Record duration of check
-    if let Some(duration) = duration {
-        metrics::histogram!(
-            "check_result.duration_ms",
-            "histogram" => "timer",
-            "status" => status_label,
-            "failure_reason" => failure_reason.unwrap_or("ok"),
-        )
-        .record(duration.num_milliseconds() as f64);
-    }
-
-    // Record time between scheduled and actual check
-    metrics::histogram!(
-        "check_result.delay_ms",
-        "histogram" => "timer",
-        "status" => status_label,
-        "failure_reason" => failure_reason.unwrap_or("ok"),
-    )
-    .record((*actual_check_time - *scheduled_check_time).num_milliseconds() as f64);
-
-    // Record status of the check
-    metrics::counter!(
-        "check_result.processed",
-        "status" => status_label,
-        "failure_reason" => failure_reason.unwrap_or("ok"),
-    )
-    .increment(1);
+    tokio::spawn(async move { scheduler_loop(config_store, executor_sender, shutdown).await })
 }
 
 async fn scheduler_loop(
     config_store: Arc<RwConfigStore>,
-    checker: Arc<impl Checker + 'static>,
-    producer: Arc<impl ResultsProducer + 'static>,
+    executor_sender: CheckSender,
     shutdown: CancellationToken,
 ) {
     let mut interval = time::interval(time::Duration::from_secs(1));
@@ -94,25 +38,12 @@ async fn scheduler_loop(
 
         metrics::gauge!("scheduler.bucket_size").set(configs.len() as f64);
 
-        let mut join_set = JoinSet::new();
+        let mut results = vec![];
 
         // TODO(epurkhiser): Check if we skipped any ticks If we did we should catch up on those.
 
-        // TODO: We should put schedule config executions into a worker using mpsc
         for config in configs {
-            let job_checker = checker.clone();
-            let job_producer = producer.clone();
-
-            join_set.spawn(async move {
-                let check_result = job_checker.check_url(&config, &tick).await;
-
-                if let Err(e) = job_producer.produce_checker_result(&check_result) {
-                    tracing::error!(error = ?e, "executor.failed_to_produce_result");
-                }
-
-                tracing::info!(result = ?check_result, "executor.check_complete");
-                record_result_metrics(&check_result);
-            });
+            results.push(queue_check(&executor_sender, tick, config));
         }
 
         // Spawn a task to wait for checks to complete.
@@ -120,14 +51,18 @@ async fn scheduler_loop(
         // TODO(epurkhiser): We'll want to record the tick timestamp  in redis or some other store
         // so that we can resume processing if we fail to process ticks (crash-loop, etc)
         tokio::spawn(async move {
-            let checks_ran = join_set.len();
-            while join_set.join_next().await.is_some() {}
+            let checks_scheduled = results.len();
+            while let Some(result) = results.pop() {
+                // TODO(epurkhiser): Do we want to do something with the CheckResult here?
+                let _check_result = result.await.expect("Failed to recieve CheckResult");
+            }
+
             let execution_duration = tick_start.elapsed();
 
             tracing::debug!(
                 result = %tick,
                 duration = ?execution_duration,
-                checks_ran,
+                checks_scheduled,
                 "scheduler.tick_execution_complete"
             );
         });
@@ -139,4 +74,61 @@ async fn scheduler_loop(
         schedule_checks(tick);
     }
     tracing::info!("scheduler.shutdown");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use chrono::Duration;
+    use similar_asserts::assert_eq;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
+
+    use crate::{config_store::ConfigStore, types::check_config::CheckConfig};
+
+    use super::run_scheduler;
+
+    #[tokio::test(start_paused = true)]
+    async fn test_scheduler() {
+        let config_store = Arc::new(ConfigStore::new_rw());
+
+        let config1 = Arc::new(CheckConfig {
+            subscription_id: Uuid::from_u128(1),
+            ..Default::default()
+        });
+        let config2 = Arc::new(CheckConfig {
+            subscription_id: Uuid::from_u128(3),
+            ..Default::default()
+        });
+
+        {
+            let mut rw_store = config_store.write().unwrap();
+            rw_store.add_config(config1.clone());
+            rw_store.add_config(config2.clone());
+        }
+
+        let (executor_tx, mut executor_rx) = mpsc::unbounded_channel();
+        let shutdown_token = CancellationToken::new();
+
+        let join_handle = run_scheduler(0, config_store, executor_tx, shutdown_token.clone());
+
+        // Wait for both ticks
+        let scheduled_check1 = executor_rx.recv().await.unwrap();
+        assert_eq!(scheduled_check1.get_config().clone(), config1);
+
+        let scheduled_check2 = executor_rx.recv().await.unwrap();
+        assert_eq!(scheduled_check2.get_config().clone(), config2);
+
+        // The second tick should have been scheduled two seconds after the first tick since it is
+        // two buckets after the first tick.
+        assert_eq!(
+            scheduled_check2.get_tick().time() - scheduled_check1.get_tick().time(),
+            Duration::seconds(2)
+        );
+
+        shutdown_token.cancel();
+        join_handle.await.unwrap();
+    }
 }


### PR DESCRIPTION
Removes the schedulers functionality of actually firing checks and
instead queues checks for execution in the check_executor.

The executor is started when the manager is started.

This allows us to write tests for the scheduler much easier now.