### PR TITLE
fix: Correctly record histogram timers as f64 secs

### DIFF
--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -171,29 +171,27 @@ fn record_result_metrics(result: &CheckResult) {
     // Record duration of check
     if let Some(duration) = duration {
         metrics::histogram!(
-            "check_result.duration_ms",
+            "check_result.duration",
             "histogram" => "timer",
             "status" => status_label,
             "failure_reason" => failure_reason.unwrap_or("ok"),
         )
-        .record(duration.num_milliseconds() as f64);
-
-        tracing::info!("duration is {}", duration.num_milliseconds() as f64);
+        .record(duration.to_std().unwrap().as_secs_f64());
     }
 
     // Record time between scheduled and actual check
+    let delay = (*actual_check_time - *scheduled_check_time)
+        .to_std()
+        .unwrap()
+        .as_secs_f64();
+
     metrics::histogram!(
-        "check_result.delay_ms",
+        "check_result.delay",
         "histogram" => "timer",
         "status" => status_label,
         "failure_reason" => failure_reason.unwrap_or("ok"),
     )
-    .record((*actual_check_time - *scheduled_check_time).num_milliseconds() as f64);
-
-    tracing::info!(
-        "delay is {}",
-        (*actual_check_time - *scheduled_check_time).num_milliseconds() as f64
-    );
+    .record(delay);
 
     // Record status of the check
     metrics::counter!(


### PR DESCRIPTION
This isn't very well documented, but the statsd exporter requires the
timer histogram value to be in f64 seconds [^1]

[^1]: https://docs.rs/metrics-exporter-statsd/latest/src/metrics_exporter_statsd/recorder.rs.html#125-131