### PR TITLE
fix(uptime): Make scheduler wait for boot before it starts scheduling ticks

### DIFF
--- a/src/config_waiter.rs
+++ b/src/config_waiter.rs
@@ -84,8 +84,10 @@ pub fn wait_for_partition_boot(
         .to_string();
         tracing::info!(boot_time_ms, total_configs, partition, boot_string);
         if shutdown.is_cancelled() {
-            boot_finished.send(BootResult::Cancelled).expect("Failed to report boot cancellation");
-            return
+            boot_finished
+                .send(BootResult::Cancelled)
+                .expect("Failed to report boot cancellation");
+            return;
         }
 
         tracing::info!(
@@ -153,7 +155,10 @@ mod tests {
         // Advance past the BOOT_IDLE_TIMEOUT, we will now have finished
         sleep(BOOT_IDLE_TIMEOUT + Duration::from_millis(100)).await;
 
-        assert_eq!(poll!(wait_booted.as_mut()), Poll::Ready(Ok(BootResult::Started)));
+        assert_eq!(
+            poll!(wait_booted.as_mut()),
+            Poll::Ready(Ok(BootResult::Started))
+        );
     }
 
     #[tokio::test(start_paused = true)]
@@ -187,6 +192,9 @@ mod tests {
         // place
         sleep(Duration::from_millis(1)).await;
         // Boot should be finished, but cancelled
-        assert_eq!(poll!(wait_booted.as_mut()), Poll::Ready(Ok(BootResult::Cancelled)));
+        assert_eq!(
+            poll!(wait_booted.as_mut()),
+            Poll::Ready(Ok(BootResult::Cancelled))
+        );
     }
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -45,9 +45,9 @@ impl PartitionedService {
         // TODO(epurkhiser): We may want to wait to start the scheduler until "booting" completes,
         // otherwise we may execute checks for old configs in a partition that are removed later in
         // the log.
-        tokio::spawn(async move { wait_for_partition_boot(waiter_config_store, partition).await });
-
         let shutdown_signal = CancellationToken::new();
+        let config_loaded = wait_for_partition_boot(waiter_config_store, partition, shutdown_signal.clone());
+
         let scheduler_join_handle = run_scheduler(
             partition,
             config_store.clone(),
@@ -55,6 +55,7 @@ impl PartitionedService {
             shutdown_signal.clone(),
             build_progress_key(partition),
             config.redis_host.clone(),
+            config_loaded,
         );
 
         Self {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -46,7 +46,8 @@ impl PartitionedService {
         // otherwise we may execute checks for old configs in a partition that are removed later in
         // the log.
         let shutdown_signal = CancellationToken::new();
-        let config_loaded = wait_for_partition_boot(waiter_config_store, partition, shutdown_signal.clone());
+        let config_loaded =
+            wait_for_partition_boot(waiter_config_store, partition, shutdown_signal.clone());
 
         let scheduler_join_handle = run_scheduler(
             partition,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -11,8 +11,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::check_executor::{queue_check, CheckSender};
 use crate::config_store::{RwConfigStore, Tick};
-use redis::{AsyncCommands, Client};
 use crate::config_waiter::BootResult;
+use redis::{AsyncCommands, Client};
 
 pub fn run_scheduler(
     partition: u16,
@@ -167,6 +167,7 @@ mod tests {
 
     use super::run_scheduler;
 
+    use crate::config_waiter::BootResult;
     use crate::manager::build_progress_key;
     use crate::{
         config_store::ConfigStore,
@@ -175,7 +176,6 @@ mod tests {
             result::{CheckResult, CheckStatus},
         },
     };
-    use crate::config_waiter::BootResult;
 
     #[traced_test]
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
We need to wait until all configs are loaded before we start scheduling ticks. Otherwise we end up missing configs due to a race condition between loading configs and processing ticks.