### PR TITLE
feat(http): Make checks using request configs

### DIFF
--- a/src/producer/kafka_producer.rs
+++ b/src/producer/kafka_producer.rs
@@ -52,9 +52,11 @@ mod tests {
     use super::KafkaResultsProducer;
     use crate::{
         producer::{ExtractCodeError, ResultsProducer},
-        types::result::{
-            CheckResult, CheckStatus, CheckStatusReason, CheckStatusReasonType, RequestInfo,
-            RequestType,
+        types::{
+            result::{
+                CheckResult, CheckStatus, CheckStatusReason, CheckStatusReasonType, RequestInfo,
+            },
+            shared::RequestMethod,
         },
     };
     use chrono::{TimeDelta, Utc};
@@ -78,7 +80,7 @@ mod tests {
             actual_check_time: Utc::now(),
             duration: Some(TimeDelta::seconds(1)),
             request_info: Some(RequestInfo {
-                request_type: RequestType::Head,
+                request_type: RequestMethod::Get,
                 http_status_code: Some(200),
             }),
         };

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,2 +1,3 @@
 pub mod check_config;
 pub mod result;
+pub mod shared;

--- a/src/types/check_config.rs
+++ b/src/types/check_config.rs
@@ -8,6 +8,8 @@ use std::{
 };
 use uuid::Uuid;
 
+use super::shared::RequestMethod;
+
 const ONE_MINUTE: isize = 60;
 
 /// Valid intervals between the checks in seconds.
@@ -24,25 +26,6 @@ pub enum CheckInterval {
 
 /// The largest check interval
 pub const MAX_CHECK_INTERVAL_SECS: usize = CheckInterval::SixtyMinutes as usize;
-
-/// Request methods available for the check configuration.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum RequestMethod {
-    Get,
-    Post,
-    Head,
-    Put,
-    Delete,
-    Patch,
-    Options,
-}
-
-impl Default for RequestMethod {
-    fn default() -> Self {
-        Self::Get
-    }
-}
 
 /// The CheckConfig represents a configuration for a single check.
 #[serde_as]

--- a/src/types/result.rs
+++ b/src/types/result.rs
@@ -5,6 +5,8 @@ use serde_with::chrono;
 use serde_with::serde_as;
 use uuid::Uuid;
 
+use super::shared::RequestMethod;
+
 fn uuid_simple<S>(uuid: &Uuid, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
@@ -30,14 +32,6 @@ pub enum CheckStatusReasonType {
     Failure,
 }
 
-/// The type of HTTP request used for the check
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum RequestType {
-    Head,
-    Get,
-}
-
 /// Captures the reason for a check's given status
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -54,7 +48,7 @@ pub struct CheckStatusReason {
 #[serde(rename_all = "snake_case")]
 pub struct RequestInfo {
     /// The type of HTTP method used for the check
-    pub request_type: RequestType,
+    pub request_type: RequestMethod,
 
     /// The status code of the response. May be empty when the request did not receive a response
     /// whatsoever.

--- a/src/types/shared.rs
+++ b/src/types/shared.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+/// Common requets methods.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum RequestMethod {
+    Get,
+    Post,
+    Head,
+    Put,
+    Delete,
+    Patch,
+    Options,
+}
+
+impl Default for RequestMethod {
+    fn default() -> Self {
+        Self::Get
+    }
+}
+
+impl From<RequestMethod> for reqwest::Method {
+    fn from(value: RequestMethod) -> Self {
+        match value {
+            RequestMethod::Get => reqwest::Method::GET,
+            RequestMethod::Post => reqwest::Method::POST,
+            RequestMethod::Head => reqwest::Method::HEAD,
+            RequestMethod::Put => reqwest::Method::PUT,
+            RequestMethod::Delete => reqwest::Method::DELETE,
+            RequestMethod::Patch => reqwest::Method::PATCH,
+            RequestMethod::Options => reqwest::Method::OPTIONS,
+        }
+    }
+}


### PR DESCRIPTION
This updates the http_checker to execute checks using the configurations in the `requets_{method,headers,body}` fields of the `CheckConfig`.