### PR TITLE
Enable sampling of spans

### DIFF
--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -102,7 +102,7 @@ impl Checker for HttpChecker {
         let span_id = SpanId::default();
 
         // Format the 'sentry-trace' header. The last byte indicates that we are forcing
-        // sampling on child spans (they will be recorded). If we were to set this to '0' 
+        // sampling on child spans (they will be recorded). If we were to set this to '0'
         // it would mean that every check request made for that customer would be NOT sampled,
         let trace_header = format!("{}-{}-{}", trace_id, span_id, '1');
 

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -101,10 +101,10 @@ impl Checker for HttpChecker {
         let trace_id = TraceId::default();
         let span_id = SpanId::default();
 
-        // Format the 'sentry-trace' header. The last byte indicates that we are NOT forcing
-        // sampling on child spans. If we were to set this to '1' it would mean that every
-        // check request made for that customer would be sampled,
-        let trace_header = format!("{}-{}-{}", trace_id, span_id, '0');
+        // Format the 'sentry-trace' header. The last byte indicates that we are forcing
+        // sampling on child spans (they will be recorded). If we were to set this to '0' 
+        // it would mean that every check request made for that customer would be NOT sampled,
+        let trace_header = format!("{}-{}-{}", trace_id, span_id, '1');
 
         let start = Instant::now();
         let response = do_request(&self.client, config, &trace_header).await;


### PR DESCRIPTION
We provide 10M spans included in every plan, so it'd take quite a while for uptime to exhaust its quota, even if sending requesting every minute. The value of seeing spans in every uptime trace is higher.