### PR TITLE
ref: Sanitize generic failure error message url

### DIFF
--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -165,7 +165,7 @@ impl Checker for HttpChecker {
                 } else {
                     CheckStatusReason {
                         status_type: CheckStatusReasonType::Failure,
-                        description: format!("{:?}", e),
+                        description: format!("{:?}", e.without_url()),
                     }
                 }
             }),


### PR DESCRIPTION
If the URL included a token or something we wouldn't sanitize it, let's avoid including the URL