### PR TITLE
feat(uptime): bump sentry kafka schemas to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,7 +1341,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -2804,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "0.1.109"
+version = "0.1.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab156c1e2600782e98d771f352cd4b89d7b172b098c005a50d18e0b0eb5bf016"
+checksum = "d429322de5d1893f2481624ba64c9b3d6ebfeff57e57d8323389848abec401c9"
 dependencies = [
  "jsonschema",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json"] }
 tracing-test = "0.2.5"
 console = "0.15.8"
-sentry-kafka-schemas = "0.1.109"
+sentry-kafka-schemas = "0.1.120"
 serde_with = { version = "3.8.1", features = ["chrono"] }
 rmp-serde = "1.3.0"
 serde_repr = "0.1.19"

--- a/src/types/check_config.rs
+++ b/src/types/check_config.rs
@@ -55,6 +55,10 @@ pub struct CheckConfig {
     /// The body to pass through to the request.
     #[serde(default)]
     pub request_body: String,
+
+    /// If we should allow sampling on the trace spans.
+    #[serde(default)]
+    pub trace_sampling: bool,
 }
 
 impl Hash for CheckConfig {
@@ -103,6 +107,7 @@ mod tests {
                 request_method: Default::default(),
                 request_headers: Default::default(),
                 request_body: Default::default(),
+                trace_sampling: false,
             }
         }
     }
@@ -131,7 +136,8 @@ mod tests {
                 url: "http://sentry.io".to_string(),
                 request_method: RequestMethod::Get,
                 request_headers: vec![],
-                request_body: "".to_string()
+                request_body: "".to_string(),
+                trace_sampling: false,
             }
         );
     }
@@ -178,7 +184,8 @@ mod tests {
                         "example value".to_string()
                     ),
                 ],
-                request_body: "{\"key\": \"value\"}".to_string()
+                request_body: "{\"key\": \"value\"}".to_string(),
+                trace_sampling: false,
             }
         );
     }


### PR DESCRIPTION
bump to latest so we get https://github.com/getsentry/sentry-kafka-schemas/pull/351

part of https://github.com/getsentry/team-uptime/issues/22