### PR TITLE
feat(uptime): Add region configuration to `CheckConfig`.

### DIFF
--- a/src/types/check_config.rs
+++ b/src/types/check_config.rs
@@ -5,7 +5,7 @@ use serde_with::serde_as;
 use std::hash::{Hash, Hasher};
 use uuid::Uuid;
 
-use super::shared::RequestMethod;
+use super::shared::{RegionScheduleMode, RequestMethod};
 
 const ONE_MINUTE: isize = 60;
 
@@ -59,6 +59,12 @@ pub struct CheckConfig {
     /// If we should allow sampling on the trace spans.
     #[serde(default)]
     pub trace_sampling: bool,
+
+    #[serde(default)]
+    pub active_regions: Option<Vec<String>>,
+
+    #[serde(default)]
+    pub region_schedule_mode: Option<RegionScheduleMode>,
 }
 
 impl Hash for CheckConfig {
@@ -94,7 +100,7 @@ mod tests {
     use uuid::{uuid, Uuid};
 
     use crate::types::check_config::MAX_CHECK_INTERVAL_SECS;
-
+    use crate::types::shared::RegionScheduleMode;
     use super::{CheckConfig, CheckInterval, RequestMethod};
 
     impl Default for CheckConfig {
@@ -108,6 +114,8 @@ mod tests {
                 request_headers: Default::default(),
                 request_body: Default::default(),
                 trace_sampling: false,
+                active_regions: None,
+                region_schedule_mode: None,
             }
         }
     }
@@ -143,6 +151,8 @@ mod tests {
                 request_headers: vec![],
                 request_body: "".to_string(),
                 trace_sampling: false,
+                active_regions: Some(vec!["us-west".to_string(), "europe".to_string()]),
+                region_schedule_mode: Some(RegionScheduleMode::RoundRobin),
             }
         );
     }
@@ -196,6 +206,8 @@ mod tests {
                 ],
                 request_body: "{\"key\": \"value\"}".to_string(),
                 trace_sampling: false,
+                active_regions: Some(vec!["us-west".to_string(), "europe".to_string()]),
+                region_schedule_mode: Some(RegionScheduleMode::RoundRobin),
             }
         );
     }

--- a/src/types/check_config.rs
+++ b/src/types/check_config.rs
@@ -99,9 +99,9 @@ mod tests {
     use similar_asserts::assert_eq;
     use uuid::{uuid, Uuid};
 
+    use super::{CheckConfig, CheckInterval, RequestMethod};
     use crate::types::check_config::MAX_CHECK_INTERVAL_SECS;
     use crate::types::shared::RegionScheduleMode;
-    use super::{CheckConfig, CheckInterval, RequestMethod};
 
     impl Default for CheckConfig {
         fn default() -> Self {

--- a/src/types/shared.rs
+++ b/src/types/shared.rs
@@ -13,6 +13,13 @@ pub enum RequestMethod {
     Options,
 }
 
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegionScheduleMode {
+    RoundRobin,
+}
+
 impl Default for RequestMethod {
     fn default() -> Self {
         Self::Get

--- a/src/types/shared.rs
+++ b/src/types/shared.rs
@@ -13,7 +13,6 @@ pub enum RequestMethod {
     Options,
 }
 
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RegionScheduleMode {


### PR DESCRIPTION
This adds `active_regions` and `region_schedule_mode` to `CheckConfig` and updates tests. These will be used to schedule checks when multiple regions are present.