### PR TITLE
feat(uptime): Add `region` to the Uptime service config.

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -58,6 +58,9 @@ pub struct Config {
 
     /// The general purpose redis node to use with this service
     pub redis_host: String,
+
+    /// The region that this checker is running in
+    pub region: String,
 }
 
 impl Default for Config {
@@ -74,6 +77,7 @@ impl Default for Config {
             configs_kafka_cluster: vec![],
             configs_kafka_topic: "uptime-configs".to_owned(),
             redis_host: "redis://127.0.0.1:6379".to_owned(),
+            region: "default".to_owned(),
         }
     }
 }
@@ -153,6 +157,7 @@ mod tests {
                     results_kafka_topic: "uptime-results".to_owned(),
                     configs_kafka_topic: "uptime-configs".to_owned(),
                     redis_host: "redis://127.0.0.1:6379".to_owned(),
+                    region: "default".to_owned(),
                 }
             );
             Ok(())
@@ -182,6 +187,7 @@ mod tests {
             );
             jail.set_env("UPTIME_CHECKER_STATSD_ADDR", "10.0.0.1:1234");
             jail.set_env("UPTIME_CHECKER_REDIS_HOST", "10.0.0.3:6379");
+            jail.set_env("UPTIME_CHECKER_REGION", "us-west");
             let app = cli::CliApp {
                 config: Some(PathBuf::from("config.yaml")),
                 log_level: Some(logging::Level::Trace),
@@ -205,6 +211,7 @@ mod tests {
                     results_kafka_topic: "uptime-results".to_owned(),
                     configs_kafka_topic: "uptime-configs".to_owned(),
                     redis_host: "10.0.0.3:6379".to_owned(),
+                    region: "us-west".to_owned(),
                 }
             );
             Ok(())

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -57,6 +57,7 @@ impl PartitionedService {
             build_progress_key(partition),
             config.redis_host.clone(),
             config_loaded,
+            config.region.clone(),
         );
 
         Self {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -14,6 +14,7 @@ use crate::config_store::{RwConfigStore, Tick};
 use crate::config_waiter::BootResult;
 use redis::{AsyncCommands, Client};
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_scheduler(
     partition: u16,
     config_store: Arc<RwConfigStore>,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -22,6 +22,7 @@ pub fn run_scheduler(
     progress_key: String,
     redis_host: String,
     config_loaded_receiver: Receiver<BootResult>,
+    region: String,
 ) -> JoinHandle<()> {
     tracing::info!(partition, "scheduler.starting");
     tokio::spawn(async move {
@@ -32,6 +33,7 @@ pub fn run_scheduler(
             shutdown,
             progress_key,
             redis_host,
+            region,
         )
         .await
     })
@@ -43,6 +45,7 @@ async fn scheduler_loop(
     shutdown: CancellationToken,
     progress_key: String,
     redis_host: String,
+    _region: String,
 ) {
     let client = Client::open(redis_host.clone()).unwrap();
     let mut connection = client
@@ -219,6 +222,7 @@ mod tests {
             build_progress_key(0),
             config.redis_host.clone(),
             boot_rx,
+            config.region.clone(),
         );
         let _ = boot_tx.send(BootResult::Started);
 
@@ -321,6 +325,7 @@ mod tests {
             progress_key.clone(),
             config.redis_host.clone(),
             boot_rx,
+            config.region.clone(),
         );
 
         let _ = boot_tx.send(BootResult::Started);


### PR DESCRIPTION
This allows region to be specified at the checker level, so that the checker knows where it is running