### PR TITLE
feat(uptime): Make sure result and trace ids are consistent for a scheduled check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,6 +3866,7 @@ checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "serde",
+ "sha1_smol",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ httpmock = "0.7.0-rc.1"
 reqwest = { version = "0.12.2", features = ["hickory-dns"] }
 rust_arroyo = { version = "*", git = "https://github.com/getsentry/arroyo", rev = "0b84afc07131d8b8d48abcb7c8de8cfa2a98e526" }
 tokio = { version = "1.28.0", features = ["macros", "sync", "tracing", "signal", "rt-multi-thread", "test-util"] }
-uuid = { version = "1.8.0", features = ["serde", "v4"] }
+uuid = { version = "1.8.0", features = ["serde", "v4", "v5"] }
 serde = { version = "1.0.159", features = ["derive", "rc"] }
 serde_json = "1.0.93"
 figment = { version = "0.10", features = ["yaml", "env", "test"] }

--- a/src/checker/dummy_checker.rs
+++ b/src/checker/dummy_checker.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use chrono::Utc;
-use sentry::protocol::{SpanId, TraceId};
+use sentry::protocol::SpanId;
 use tokio::time;
 use uuid::Uuid;
 
@@ -27,7 +27,7 @@ impl Checker for DummyChecker {
     async fn check_url(&self, config: &CheckConfig, tick: &Tick, region: &str) -> CheckResult {
         let scheduled_check_time = tick.time();
         let actual_check_time = Utc::now();
-        let trace_id = TraceId::default();
+        let trace_id = Uuid::new_v4();
         let span_id = SpanId::default();
         let duration = None;
         let status = CheckStatus::Success;

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -1,7 +1,7 @@
 use chrono::{TimeDelta, Utc};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::{Client, ClientBuilder, Response};
-use sentry::protocol::{SpanId, TraceId};
+use sentry::protocol::SpanId;
 use std::error::Error;
 use tokio::time::Instant;
 use uuid::Uuid;
@@ -14,6 +14,8 @@ use crate::types::{
 
 use super::ip_filter::is_external_ip;
 use super::Checker;
+
+pub const CHECKER_RESULT_NAMESPACE: Uuid = Uuid::from_u128(0x67f0b2d5_e476_4f00_9b99_9e6b95c3b7e3);
 
 const UPTIME_USER_AGENT: &str =
     "SentryUptimeBot/1.0 (+http://docs.sentry.io/product/alerts/uptime-monitoring/)";
@@ -109,7 +111,7 @@ impl HttpChecker {
     }
 }
 
-fn make_trace_header(config: &CheckConfig, trace_id: TraceId, span_id: SpanId) -> String {
+fn make_trace_header(config: &CheckConfig, trace_id: &Uuid, span_id: SpanId) -> String {
     // Format the 'sentry-trace' header. if we append a 0 to the header,
     // we're indicating the trace spans will not be sampled.
     // if we don't append a 0, then the default behavior is to sample the trace spans
@@ -130,10 +132,10 @@ impl Checker for HttpChecker {
     async fn check_url(&self, config: &CheckConfig, tick: &Tick, region: &str) -> CheckResult {
         let scheduled_check_time = tick.time();
         let actual_check_time = Utc::now();
-        let trace_id = TraceId::default();
         let span_id = SpanId::default();
-
-        let trace_header = make_trace_header(config, trace_id, span_id);
+        let unique_key = format!("{}-{}", config.subscription_id, scheduled_check_time);
+        let guid = Uuid::new_v5(&CHECKER_RESULT_NAMESPACE, unique_key.as_bytes());
+        let trace_header = make_trace_header(config, &guid, span_id);
 
         let start = Instant::now();
         let response = do_request(&self.client, config, &trace_header).await;
@@ -182,11 +184,11 @@ impl Checker for HttpChecker {
         };
 
         CheckResult {
-            guid: Uuid::new_v4(),
+            guid,
             subscription_id: config.subscription_id,
             status,
             status_reason,
-            trace_id,
+            trace_id: guid,
             span_id,
             scheduled_check_time,
             actual_check_time,
@@ -210,7 +212,8 @@ mod tests {
     use chrono::{TimeDelta, Utc};
     use httpmock::prelude::*;
     use httpmock::Method;
-    use sentry::protocol::{SpanId, TraceId};
+    use sentry::protocol::SpanId;
+    use uuid::Uuid;
 
     fn make_tick() -> Tick {
         Tick::from_time(Utc::now() - TimeDelta::seconds(60))
@@ -433,8 +436,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_same_check_same_id() {
+        let server = MockServer::start();
+        let checker = HttpChecker::new_internal(Options {
+            validate_url: false,
+        });
+
+        let get_mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/no-head")
+                .header_exists("sentry-trace")
+                .header("User-Agent", UPTIME_USER_AGENT.to_string());
+            then.status(200);
+        });
+
+        let config = CheckConfig {
+            url: server.url("/no-head").to_string(),
+            ..Default::default()
+        };
+
+        let tick = make_tick();
+        let result = checker.check_url(&config, &tick, "us-west").await;
+        let result_2 = checker.check_url(&config, &tick, "us-west").await;
+
+        assert_eq!(result.status, CheckStatus::Success);
+        assert_eq!(result_2.status, CheckStatus::Success);
+        assert_eq!(result.guid, result_2.guid);
+        assert_eq!(result.trace_id, result_2.trace_id);
+        get_mock.assert_hits(2);
+    }
+
+
+    #[tokio::test]
     async fn test_trace_sampling() {
-        let trace_id = TraceId::default();
+        let trace_id = Uuid::new_v4();
         let span_id = SpanId::default();
 
         // Test with sampling disabled
@@ -443,7 +478,7 @@ mod tests {
             trace_sampling: false,
             ..Default::default()
         };
-        let trace_header = make_trace_header(&config, trace_id, span_id);
+        let trace_header = make_trace_header(&config, &trace_id, span_id);
         assert_eq!(trace_header, format!("{}-{}-0", trace_id, span_id));
 
         // Test with sampling enabled
@@ -452,7 +487,7 @@ mod tests {
             trace_sampling: true,
             ..Default::default()
         };
-        let trace_header_sampling = make_trace_header(&config_with_sampling, trace_id, span_id);
+        let trace_header_sampling = make_trace_header(&config_with_sampling, &trace_id, span_id);
         assert_eq!(trace_header_sampling, format!("{}-{}", trace_id, span_id));
     }
     // TODO: Figure out how to simulate a DNS failure

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -466,7 +466,6 @@ mod tests {
         get_mock.assert_hits(2);
     }
 
-
     #[tokio::test]
     async fn test_trace_sampling() {
         let trace_id = Uuid::new_v4();

--- a/src/producer/kafka_producer.rs
+++ b/src/producer/kafka_producer.rs
@@ -62,7 +62,7 @@ mod tests {
     };
     use chrono::{TimeDelta, Utc};
     use rust_arroyo::backends::kafka::config::KafkaConfig;
-    use sentry::protocol::{SpanId, TraceId};
+    use sentry::protocol::SpanId;
     use uuid::{uuid, Uuid};
 
     pub fn send_result(result: CheckStatus) -> Result<(), ExtractCodeError> {
@@ -75,7 +75,7 @@ mod tests {
                 status_type: CheckStatusReasonType::DnsError,
                 description: "hi".to_string(),
             }),
-            trace_id: TraceId::default(),
+            trace_id: guid,
             span_id: SpanId::default(),
             scheduled_check_time: Utc::now(),
             actual_check_time: Utc::now(),

--- a/src/types/result.rs
+++ b/src/types/result.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, TimeDelta, Utc};
-use sentry::protocol::{SpanId, TraceId};
+use sentry::protocol::SpanId;
 use serde::{Deserialize, Serialize};
 use serde_with::chrono;
 use serde_with::serde_as;
@@ -74,7 +74,8 @@ pub struct CheckResult {
     pub status_reason: Option<CheckStatusReason>,
 
     /// Trace ID associated with the check-in made
-    pub trace_id: TraceId,
+    #[serde(serialize_with = "uuid_simple")]
+    pub trace_id: Uuid,
 
     /// Span ID associated with the check-in made
     pub span_id: SpanId,


### PR DESCRIPTION
We want to ensure that we produce the same ids for the same check. Each scheduled check is uniquely identified via the subscription id and scheduled time. Having these ids be consistent makes it easy for us to de-dupe data if we have duplicates due to a deploy or other issue.