### PR TITLE
feat: allow internal ips for self-hosted instances

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -61,6 +61,9 @@ pub struct Config {
 
     /// The region that this checker is running in
     pub region: String,
+
+    /// Allow uptime checks against internal IP addresses
+    pub allow_internal_ips: bool,
 }
 
 impl Default for Config {
@@ -78,6 +81,7 @@ impl Default for Config {
             configs_kafka_topic: "uptime-configs".to_owned(),
             redis_host: "redis://127.0.0.1:6379".to_owned(),
             region: "default".to_owned(),
+            allow_internal_ips: false,
         }
     }
 }
@@ -158,6 +162,7 @@ mod tests {
                     configs_kafka_topic: "uptime-configs".to_owned(),
                     redis_host: "redis://127.0.0.1:6379".to_owned(),
                     region: "default".to_owned(),
+                    allow_internal_ips: false,
                 }
             );
             Ok(())
@@ -188,6 +193,7 @@ mod tests {
             jail.set_env("UPTIME_CHECKER_STATSD_ADDR", "10.0.0.1:1234");
             jail.set_env("UPTIME_CHECKER_REDIS_HOST", "10.0.0.3:6379");
             jail.set_env("UPTIME_CHECKER_REGION", "us-west");
+            jail.set_env("UPTIME_CHECKER_ALLOW_INTERNAL_IPS", "true");
             let app = cli::CliApp {
                 config: Some(PathBuf::from("config.yaml")),
                 log_level: Some(logging::Level::Trace),
@@ -212,6 +218,7 @@ mod tests {
                     configs_kafka_topic: "uptime-configs".to_owned(),
                     redis_host: "10.0.0.3:6379".to_owned(),
                     region: "us-west".to_owned(),
+                    allow_internal_ips: true,
                 }
             );
             Ok(())

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -122,8 +122,10 @@ impl HttpChecker {
         Self { client }
     }
 
-    pub fn new() -> Self {
-        Self::new_internal(Default::default())
+    pub fn new(validate_url: bool) -> Self {
+        Self::new_internal(Options {
+            validate_url,
+        })
     }
 }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -105,7 +105,7 @@ impl Manager {
     /// The returned shutdown function may be called to stop the consumer and thus shutdown all
     /// PartitionedService's, stopping check execution.
     pub fn start(config: Arc<Config>) -> impl FnOnce() -> Pin<Box<dyn Future<Output = ()>>> {
-        let checker = Arc::new(HttpChecker::new());
+        let checker = Arc::new(HttpChecker::new(!config.allow_internal_ips));
 
         let kafka_overrides = HashMap::from([("compression.type".to_string(), "lz4".to_string())]);
 


### PR DESCRIPTION
For self-hosted use cases, we will be checking against private IP address space, most of the times. Since most of the self-hosted deployment are done in a private (and mostly air-gapped) environment.

This PR introduces `allow_internal_ips` on the configuration that hopefully does not break with existing running instances.