### PR TITLE
fix: make max_idle_per_host 0

### DIFF
--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -129,15 +129,16 @@ impl HttpChecker {
             builder = builder.ip_filter(is_external_ip);
         }
 
-        let client = builder.pool_max_idle_per_host(0).build().expect("Failed to build checker client");
+        let client = builder
+            .pool_max_idle_per_host(0)
+            .build()
+            .expect("Failed to build checker client");
 
         Self { client }
     }
 
     pub fn new(validate_url: bool) -> Self {
-        Self::new_internal(Options {
-            validate_url,
-        })
+        Self::new_internal(Options { validate_url })
     }
 }
 

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -129,7 +129,7 @@ impl HttpChecker {
             builder = builder.ip_filter(is_external_ip);
         }
 
-        let client = builder.build().expect("Failed to build checker client");
+        let client = builder.pool_max_idle_per_host(0).build().expect("Failed to build checker client");
 
         Self { client }
     }


### PR DESCRIPTION
we intermittently receive reports that we generate a downtime issue with the decription being `IncompleteMessageError`, and our customers say that their website was in fact up, not down. According to https://github.com/hyperium/hyper/issues/2136, this could be due to connection pooling / a race condition between the client and server. one of the comments suggests setting the connection pool timeout to `0`. https://github.com/hyperium/hyper/issues/2136#issuecomment-861826148

we do not need connection pooling as we aren't making that many requests to one particular host, so there should be no effect, and we can monitor if this fixes the error.