### PR TITLE
feat(metrics): Record queue size of executor as a metric

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -236,6 +236,7 @@ impl Manager {
 #[cfg(test)]
 mod tests {
     use crate::app::config::Config;
+    use crate::check_executor::CheckSender;
     use crate::manager::{Manager, PartitionedService};
     use std::collections::{HashMap, HashSet};
     use std::sync::{Arc, RwLock};
@@ -245,7 +246,7 @@ mod tests {
 
     impl Manager {
         pub fn start_without_consumer(config: Arc<Config>) -> Arc<Self> {
-            let (executor_sender, _) = mpsc::unbounded_channel();
+            let (executor_sender, _) = CheckSender::new();
             let (shutdown_sender, mut shutdown_service_rx) = mpsc::unbounded_channel();
 
             let manager = Arc::new(Self {
@@ -267,7 +268,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_partitioned_service_get_config_store() {
-        let (executor_sender, _) = mpsc::unbounded_channel();
+        let (executor_sender, _) = CheckSender::new();
         let service = PartitionedService::start(Arc::new(Config::default()), executor_sender, 0);
         service.get_config_store();
         service.stop().await;
@@ -275,7 +276,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_start_stop() {
-        let (executor_sender, _) = mpsc::unbounded_channel();
+        let (executor_sender, _) = CheckSender::new();
         let service = PartitionedService::start(Arc::new(Config::default()), executor_sender, 0);
         service.stop().await;
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -168,12 +168,13 @@ async fn scheduler_loop(
 #[cfg(test)]
 mod tests {
     use crate::app::config::Config;
+    use crate::check_executor::CheckSender;
     use chrono::{Duration, Utc};
     use redis::{Client, Commands};
     use redis_test_macro::redis_test;
     use similar_asserts::assert_eq;
     use std::sync::Arc;
-    use tokio::sync::{mpsc, oneshot};
+    use tokio::sync::oneshot;
     use tokio_util::sync::CancellationToken;
     use tracing_test::traced_test;
     use uuid::Uuid;
@@ -221,7 +222,7 @@ mod tests {
             rw_store.add_config(config2.clone());
         }
 
-        let (executor_tx, mut executor_rx) = mpsc::unbounded_channel();
+        let (executor_tx, mut executor_rx) = CheckSender::new();
         let (boot_tx, boot_rx) = oneshot::channel::<BootResult>();
         let shutdown_token = CancellationToken::new();
 
@@ -329,7 +330,7 @@ mod tests {
             rw_store.add_config(config2.clone());
         }
 
-        let (executor_tx, mut executor_rx) = mpsc::unbounded_channel();
+        let (executor_tx, mut executor_rx) = CheckSender::new();
         let (boot_tx, boot_rx) = oneshot::channel::<BootResult>();
         let shutdown_token = CancellationToken::new();
 
@@ -434,7 +435,7 @@ mod tests {
             rw_store.add_config(config2.clone());
         }
 
-        let (executor_tx, mut executor_rx) = mpsc::unbounded_channel();
+        let (executor_tx, mut executor_rx) = CheckSender::new();
         let (boot_tx, boot_rx) = oneshot::channel::<BootResult>();
         let shutdown_token = CancellationToken::new();
 


### PR DESCRIPTION
This will allow us to monitor how many checks are being executed concurrently over time. Since we have a concurrency limit this will also help us understand when we're getting close to that limit