### PR TITLE
fix(build): pull docker image before building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM rust:1.80-alpine3.20 as builder
 
-ARG UPTIME_CHECKER_GIT_REVISION
-ENV UPTIME_CHECKER_GIT_REVISION=$UPTIME_CHECKER_GIT_REVISION
+
 
 RUN mkdir -p ~/.cargo && \
     echo '[registries.crates-io]' > ~/.cargo/config && \
@@ -25,6 +24,9 @@ RUN cargo build --release && rm -rf src/
 
 # Copy the source code and run the build again. This should only compile the
 # app itself as the dependencies were already built above.
+ARG UPTIME_CHECKER_GIT_REVISION
+ENV UPTIME_CHECKER_GIT_REVISION=$UPTIME_CHECKER_GIT_REVISION
+
 COPY . ./
 RUN rm target/release/deps/uptime_checker* && cargo build --release
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,9 @@
 steps:
   - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: ['-c', 'docker pull us-central1-docker.pkg.dev/$PROJECT_ID/uptime-checker/image:latest || exit 0']
+
+  - name: 'gcr.io/cloud-builders/docker'
     args:
       [
         'build',


### PR DESCRIPTION
looking at our docker builds and why they're so slow, i noticed its not using the docker image cache, so its just building from scratch every time.  [link](https://console.cloud.google.com/cloud-build/builds/cf7b799e-e730-4d9b-8dce-1ec966367953?project=345757944225&invt=AbnoWw&inv=1)

according to these docs you have to pull the image for cacheing to work. 
https://cloud.google.com/build/docs/optimize-builds/speeding-up-builds

will see if the build on this branch is faster and if so, can merge.