### PR TITLE
feat(uptime): Add function to determine which partitions a checker owns

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -248,7 +248,10 @@ mod tests {
             );
             jail.set_env("UPTIME_CHECKER_CONFIG_PROVIDER_MODE", "kafka");
             jail.set_env("UPTIME_CHECKER_CONFIG_PROVIDER_REDIS_UPDATE_MS", "2000");
-            jail.set_env("UPTIME_CHECKER_CONFIG_PROVIDER_REDIS_TOTAL_PARTITIONS", "32");
+            jail.set_env(
+                "UPTIME_CHECKER_CONFIG_PROVIDER_REDIS_TOTAL_PARTITIONS",
+                "32",
+            );
             jail.set_env("UPTIME_CHECKER_STATSD_ADDR", "10.0.0.1:1234");
             jail.set_env("UPTIME_CHECKER_REDIS_HOST", "10.0.0.3:6379");
             jail.set_env("UPTIME_CHECKER_REGION", "us-west");

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -84,7 +84,7 @@ pub struct Config {
 
     /// How many config partitions do we want to keep in redis? We shouldn't change this once
     /// assigned unless we plan a migration process.
-    pub config_provider_redis_total_partitions: u64,
+    pub config_provider_redis_total_partitions: u16,
 
     /// The general purpose redis node to use with this service
     pub redis_host: String,
@@ -99,7 +99,7 @@ pub struct Config {
     pub checker_id: String,
 
     /// Total number of uptime checkers running
-    pub total_checkers: usize,
+    pub total_checkers: u16,
 }
 
 impl Default for Config {

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -5,6 +5,7 @@ use figment::{
     Figment,
 };
 
+use serde::{de, Deserializer};
 use serde::{Deserialize, Serialize};
 use serde_with::formats::CommaSeparator;
 use serde_with::serde_as;
@@ -95,8 +96,11 @@ pub struct Config {
     /// Allow uptime checks against internal IP addresses
     pub allow_internal_ips: bool,
 
-    /// Name of the pod that is running
-    pub checker_id: String,
+    #[serde(rename = "checker_id")]
+    #[serde(skip_serializing)]
+    #[serde(deserialize_with = "deserialize_checker_number")]
+    #[serde(default)]
+    pub checker_number: u16,
 
     /// Total number of uptime checkers running
     pub total_checkers: u16,
@@ -125,7 +129,7 @@ impl Default for Config {
             redis_host: "redis://127.0.0.1:6379".to_owned(),
             region: "default".to_owned(),
             allow_internal_ips: false,
-            checker_id: "default".to_owned(),
+            checker_number: 0,
             total_checkers: 1,
         }
     }
@@ -156,6 +160,20 @@ impl Config {
     }
 }
 
+fn deserialize_checker_number<'de, D>(deserializer: D) -> Result<u16, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let checker_id: String = String::deserialize(deserializer)?;
+    let ordinal = checker_id
+        .split('-')
+        .last()
+        .ok_or_else(|| de::Error::custom("checker_id should be in format <name>-<checker_number>"))?
+        .parse::<u16>()
+        .map_err(|_| de::Error::custom("checker_id should contain a valid checker_number"))?;
+    Ok(ordinal)
+}
+
 #[cfg(test)]
 mod tests {
     use std::{borrow::Cow, collections::BTreeMap, path::PathBuf};
@@ -165,25 +183,18 @@ mod tests {
 
     use crate::{app::cli, logging};
 
-    use super::{Config, ConfigProviderMode, MetricsConfig};
+    use super::{deserialize_checker_number, Config, ConfigProviderMode, MetricsConfig};
 
-    #[test]
-    fn test_simple() {
+    fn test_with_config<F>(yaml: &str, env_vars: &[(&str, &str)], test_fn: F)
+    where
+        F: FnOnce(Config),
+    {
         Jail::expect_with(|jail| {
-            jail.create_file(
-                "config.yaml",
-                r#"
-                sentry_dsn: my_dsn
-                sentry_env: my_env
-                checker_concurrency: 100
-                results_kafka_cluster: '10.0.0.1,10.0.0.2:9000'
-                configs_kafka_cluster: '10.0.0.1,10.0.0.2:9000'
-                statsd_addr: 10.0.0.1:8126
-                default_tags: {"someTag": "value"}
-                hostname_tag: pod_name
-                redis_host: redis://127.0.0.1:6379
-                "#,
-            )?;
+            jail.create_file("config.yaml", yaml)?;
+
+            for (key, value) in env_vars {
+                jail.set_env(key, value);
+            }
 
             let app = cli::CliApp {
                 config: Some(PathBuf::from("config.yaml")),
@@ -192,109 +203,204 @@ mod tests {
                 command: cli::Commands::Run,
             };
 
-            let config = Config::extract(&app).expect("Invalid configuration");
-
-            assert_eq!(
-                config,
-                Config {
-                    sentry_dsn: Some("my_dsn".to_owned()),
-                    sentry_env: Some(Cow::from("my_env")),
-                    checker_concurrency: 100,
-                    log_level: logging::Level::Warn,
-                    log_format: logging::LogFormat::Auto,
-                    metrics: MetricsConfig {
-                        statsd_addr: "10.0.0.1:8126".parse().unwrap(),
-                        default_tags: BTreeMap::from([("someTag".to_owned(), "value".to_owned()),]),
-                        hostname_tag: Some("pod_name".to_owned()),
-                    },
-                    results_kafka_cluster: vec!["10.0.0.1".to_owned(), "10.0.0.2:9000".to_owned()],
-                    configs_kafka_cluster: vec!["10.0.0.1".to_owned(), "10.0.0.2:9000".to_owned()],
-                    results_kafka_topic: "uptime-results".to_owned(),
-                    configs_kafka_topic: "uptime-configs".to_owned(),
-                    config_provider_mode: ConfigProviderMode::Kafka,
-                    config_provider_redis_update_ms: 1000,
-                    config_provider_redis_total_partitions: 128,
-                    redis_host: "redis://127.0.0.1:6379".to_owned(),
-                    region: "default".to_owned(),
-                    allow_internal_ips: false,
-                    checker_id: "default".to_owned(),
-                    total_checkers: 1,
-                }
-            );
+            let config = Config::extract(&app).unwrap();
+            test_fn(config);
             Ok(())
-        });
+        })
+    }
+
+    #[test]
+    fn test_simple() {
+        test_with_config(
+            r#"
+            sentry_dsn: my_dsn
+            sentry_env: my_env
+            checker_concurrency: 100
+            results_kafka_cluster: '10.0.0.1,10.0.0.2:9000'
+            configs_kafka_cluster: '10.0.0.1,10.0.0.2:9000'
+            statsd_addr: 10.0.0.1:8126
+            default_tags: {"someTag": "value"}
+            hostname_tag: pod_name
+            redis_host: redis://127.0.0.1:6379
+            "#,
+            &[],
+            |config| {
+                assert_eq!(
+                    config,
+                    Config {
+                        sentry_dsn: Some("my_dsn".to_owned()),
+                        sentry_env: Some(Cow::from("my_env")),
+                        checker_concurrency: 100,
+                        log_level: logging::Level::Warn,
+                        log_format: logging::LogFormat::Auto,
+                        metrics: MetricsConfig {
+                            statsd_addr: "10.0.0.1:8126".parse().unwrap(),
+                            default_tags: BTreeMap::from([(
+                                "someTag".to_owned(),
+                                "value".to_owned()
+                            ),]),
+                            hostname_tag: Some("pod_name".to_owned()),
+                        },
+                        results_kafka_cluster: vec![
+                            "10.0.0.1".to_owned(),
+                            "10.0.0.2:9000".to_owned()
+                        ],
+                        configs_kafka_cluster: vec![
+                            "10.0.0.1".to_owned(),
+                            "10.0.0.2:9000".to_owned()
+                        ],
+                        results_kafka_topic: "uptime-results".to_owned(),
+                        configs_kafka_topic: "uptime-configs".to_owned(),
+                        config_provider_mode: ConfigProviderMode::Kafka,
+                        config_provider_redis_update_ms: 1000,
+                        config_provider_redis_total_partitions: 128,
+                        redis_host: "redis://127.0.0.1:6379".to_owned(),
+                        region: "default".to_owned(),
+                        allow_internal_ips: false,
+                        checker_number: 0,
+                        total_checkers: 1,
+                    }
+                );
+            },
+        )
     }
 
     #[test]
     fn test_overrides() {
-        Jail::expect_with(|jail| {
-            jail.create_file(
-                "config.yaml",
-                r#"
-                sentry_dsn: my_dsn
-                sentry_env: my_env
-                log_format: json
-                "#,
-            )?;
+        test_with_config(
+            r#"
+            sentry_dsn: my_dsn
+            sentry_env: my_env
+            log_format: json
+            "#,
+            &[
+                ("UPTIME_CHECKER_SENTRY_ENV", "my_env_override"),
+                (
+                    "UPTIME_CHECKER_RESULTS_KAFKA_CLUSTER",
+                    "10.0.0.1,10.0.0.2:7000",
+                ),
+                (
+                    "UPTIME_CHECKER_CONFIGS_KAFKA_CLUSTER",
+                    "10.0.0.1,10.0.0.2:7000",
+                ),
+                ("UPTIME_CHECKER_CONFIG_PROVIDER_MODE", "kafka"),
+                ("UPTIME_CHECKER_CONFIG_PROVIDER_REDIS_UPDATE_MS", "2000"),
+                (
+                    "UPTIME_CHECKER_CONFIG_PROVIDER_REDIS_TOTAL_PARTITIONS",
+                    "32",
+                ),
+                ("UPTIME_CHECKER_STATSD_ADDR", "10.0.0.1:1234"),
+                ("UPTIME_CHECKER_REDIS_HOST", "10.0.0.3:6379"),
+                ("UPTIME_CHECKER_REGION", "us-west"),
+                ("UPTIME_CHECKER_ALLOW_INTERNAL_IPS", "true"),
+                ("UPTIME_CHECKER_CHECKER_ID", "somePodName-2"),
+                ("UPTIME_CHECKER_TOTAL_CHECKERS", "5"),
+            ],
+            |config| {
+                assert_eq!(
+                    config,
+                    Config {
+                        sentry_dsn: Some("my_dsn".to_owned()),
+                        sentry_env: Some(Cow::from("my_env_override")),
+                        checker_concurrency: 200,
+                        log_level: logging::Level::Warn,
+                        log_format: logging::LogFormat::Json,
+                        metrics: MetricsConfig {
+                            statsd_addr: "10.0.0.1:1234".parse().unwrap(),
+                            default_tags: BTreeMap::new(),
+                            hostname_tag: None,
+                        },
+                        results_kafka_cluster: vec![
+                            "10.0.0.1".to_owned(),
+                            "10.0.0.2:7000".to_owned()
+                        ],
+                        configs_kafka_cluster: vec![
+                            "10.0.0.1".to_owned(),
+                            "10.0.0.2:7000".to_owned()
+                        ],
+                        results_kafka_topic: "uptime-results".to_owned(),
+                        configs_kafka_topic: "uptime-configs".to_owned(),
+                        config_provider_mode: ConfigProviderMode::Kafka,
+                        config_provider_redis_update_ms: 2000,
+                        config_provider_redis_total_partitions: 32,
+                        redis_host: "10.0.0.3:6379".to_owned(),
+                        region: "us-west".to_owned(),
+                        allow_internal_ips: true,
+                        checker_number: 2,
+                        total_checkers: 5,
+                    }
+                );
+            },
+        )
+    }
 
-            jail.set_env("UPTIME_CHECKER_SENTRY_ENV", "my_env_override");
-            jail.set_env(
-                "UPTIME_CHECKER_RESULTS_KAFKA_CLUSTER",
-                "10.0.0.1,10.0.0.2:7000",
-            );
-            jail.set_env(
-                "UPTIME_CHECKER_CONFIGS_KAFKA_CLUSTER",
-                "10.0.0.1,10.0.0.2:7000",
-            );
-            jail.set_env("UPTIME_CHECKER_CONFIG_PROVIDER_MODE", "kafka");
-            jail.set_env("UPTIME_CHECKER_CONFIG_PROVIDER_REDIS_UPDATE_MS", "2000");
-            jail.set_env(
-                "UPTIME_CHECKER_CONFIG_PROVIDER_REDIS_TOTAL_PARTITIONS",
-                "32",
-            );
-            jail.set_env("UPTIME_CHECKER_STATSD_ADDR", "10.0.0.1:1234");
-            jail.set_env("UPTIME_CHECKER_REDIS_HOST", "10.0.0.3:6379");
-            jail.set_env("UPTIME_CHECKER_REGION", "us-west");
-            jail.set_env("UPTIME_CHECKER_ALLOW_INTERNAL_IPS", "true");
-            jail.set_env("UPTIME_CHECKER_CHECKER_ID", "somePodName");
-            jail.set_env("UPTIME_CHECKER_TOTAL_CHECKERS", "5");
-            let app = cli::CliApp {
-                config: Some(PathBuf::from("config.yaml")),
-                log_level: Some(logging::Level::Trace),
-                log_format: None,
-                command: cli::Commands::Run,
-            };
+    #[test]
+    fn test_config_default_checker_ordinal() {
+        test_with_config(
+            r#"
+            sentry_dsn: my_dsn
+            sentry_env: my_env
+            "#,
+            &[],
+            |config| {
+                assert_eq!(config.checker_number, 0);
+            },
+        )
+    }
 
-            let config = Config::extract(&app).expect("Invalid configuration");
+    #[test]
+    #[should_panic(
+        expected = "checker_id should contain a valid checker_number for key \"default.checker_id\" in config.yaml YAML file"
+    )]
+    fn test_config_bad_checker_id() {
+        test_with_config(
+            r#"
+            sentry_dsn: my_dsn
+            sentry_env: my_env
+            checker_id: bad-name
+            "#,
+            &[],
+            |config| {
+                assert_eq!(config.checker_number, 0);
+            },
+        )
+    }
 
-            assert_eq!(
-                config,
-                Config {
-                    sentry_dsn: Some("my_dsn".to_owned()),
-                    sentry_env: Some(Cow::from("my_env_override")),
-                    checker_concurrency: 200,
-                    log_level: logging::Level::Trace,
-                    log_format: logging::LogFormat::Json,
-                    metrics: MetricsConfig {
-                        statsd_addr: "10.0.0.1:1234".parse().unwrap(),
-                        default_tags: BTreeMap::new(),
-                        hostname_tag: None,
-                    },
-                    results_kafka_cluster: vec!["10.0.0.1".to_owned(), "10.0.0.2:7000".to_owned()],
-                    configs_kafka_cluster: vec!["10.0.0.1".to_owned(), "10.0.0.2:7000".to_owned()],
-                    results_kafka_topic: "uptime-results".to_owned(),
-                    configs_kafka_topic: "uptime-configs".to_owned(),
-                    config_provider_mode: ConfigProviderMode::Kafka,
-                    config_provider_redis_update_ms: 2000,
-                    config_provider_redis_total_partitions: 32,
-                    redis_host: "10.0.0.3:6379".to_owned(),
-                    region: "us-west".to_owned(),
-                    allow_internal_ips: true,
-                    checker_id: "somePodName".to_owned(),
-                    total_checkers: 5,
-                }
-            );
-            Ok(())
-        });
+    #[test]
+    #[should_panic(
+        expected = "checker_id should contain a valid checker_number for key \"CHECKER_ID\" in `UPTIME_CHECKER_` environment variable(s)"
+    )]
+    fn test_env_bad_checker_id() {
+        test_with_config(
+            r#"
+            sentry_dsn: my_dsn
+            sentry_env: my_env
+            "#,
+            &[("UPTIME_CHECKER_CHECKER_ID", "somePodName")],
+            |config| {
+                assert_eq!(config.checker_number, 0);
+            },
+        )
+    }
+
+    fn parse_checker_ordinal(checker_id: &str) -> u16 {
+        deserialize_checker_number(serde_json::Value::String(checker_id.to_string()))
+            .expect("Failed to parse checker_id")
+    }
+    #[test]
+    #[should_panic(expected = "checker_id should contain a valid checker_number")]
+    fn test_checker_number_no_hyphen() {
+        parse_checker_ordinal("invalid");
+    }
+
+    #[test]
+    #[should_panic(expected = "checker_id should contain a valid checker_number")]
+    fn test_checker_number_invalid_number() {
+        parse_checker_ordinal("pod-abc");
+    }
+
+    #[test]
+    fn test_checker_number_valid() {
+        assert_eq!(parse_checker_ordinal("pod-1"), 1);
     }
 }

--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -601,18 +601,8 @@ mod tests {
         run_determine_owned_partition_test(2, 0, 1, vec![0, 1]);
         run_determine_owned_partition_test(2, 0, 2, vec![0]);
         run_determine_owned_partition_test(2, 1, 2, vec![1]);
-        run_determine_owned_partition_test(
-            100,
-            1,
-            10,
-            vec![1, 11, 21, 31, 41, 51, 61, 71, 81, 91],
-        );
-        run_determine_owned_partition_test(
-            100,
-            9,
-            10,
-            vec![9, 19, 29, 39, 49, 59, 69, 79, 89, 99],
-        );
+        run_determine_owned_partition_test(100, 1, 10, vec![1, 11, 21, 31, 41, 51, 61, 71, 81, 91]);
+        run_determine_owned_partition_test(100, 9, 10, vec![9, 19, 29, 39, 49, 59, 69, 79, 89, 99]);
     }
 
     #[tokio::test]
@@ -620,5 +610,4 @@ mod tests {
     async fn test_determine_owned_partitions_checker_number_too_high() {
         run_determine_owned_partition_test(2, 1, 1, vec![0, 1]);
     }
-
 }

--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -639,5 +639,4 @@ mod tests {
     async fn test_determine_owned_partitions_invalid() {
         run_determine_owned_partition_test(2, "test-a", 1, vec![0, 1]);
     }
-
 }

--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -433,6 +433,7 @@ mod tests {
     #[redis_test(start_paused = false)]
     async fn test_redis_config_provider_load() {
         let (config, mut conn, partitions, manager, shutdown) = setup_test().await;
+        assert_eq!(partitions.len(), 2);
         let partition_configs = partitions
             .iter()
             .map(|p| {
@@ -519,7 +520,7 @@ mod tests {
     #[redis_test(start_paused = false)]
     async fn test_redis_config_provider_updates() {
         let (config, conn, partitions, manager, shutdown) = setup_test().await;
-
+        assert_eq!(partitions.len(), 2);
         let _handle = run_config_provider(&config, manager.clone(), shutdown.clone());
 
         tokio::time::sleep(Duration::from_millis(30)).await;

--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -308,13 +308,12 @@ impl RedisConfigProvider {
 pub fn run_config_provider(
     config: &Config,
     manager: Arc<Manager>,
-    partitions: HashSet<u16>,
     shutdown: CancellationToken,
 ) -> JoinHandle<()> {
     // Initializes the redis config provider and starts monitoring for config updates
     let provider = RedisConfigProvider::new(
         &config.redis_host,
-        partitions,
+        determine_owned_partitions(config),
         Duration::from_millis(config.config_provider_redis_update_ms),
     )
     .expect("Failed to create Redis config provider");
@@ -339,6 +338,28 @@ pub fn run_config_provider(
     })
 }
 
+pub fn determine_owned_partitions(config: &Config) -> HashSet<u16> {
+    // Determines which partitions this checker owns based on number of partitions,
+    // number of checkers and checker number
+    let checker_number: u16 = config
+        .checker_id
+        .split('-')
+        .last()
+        .expect("checker_id should be in format <name>-<checker_number>")
+        .parse()
+        .expect("checker_id does not contain a valid checker_number");
+    if checker_number >= config.total_checkers {
+        panic!(
+            "checker_number {} must be less than total_checkers {}",
+            checker_number, config.total_checkers
+        );
+    }
+
+    (checker_number..config.config_provider_redis_total_partitions)
+        .step_by(config.total_checkers.into())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -348,7 +369,6 @@ mod tests {
 
     async fn setup_test() -> (
         Config,
-        HashSet<u16>,
         redis::aio::MultiplexedConnection,
         Vec<RedisPartition>,
         Arc<Manager>,
@@ -356,6 +376,9 @@ mod tests {
     ) {
         let config = Config {
             config_provider_redis_update_ms: 10,
+            config_provider_redis_total_partitions: 2,
+            checker_id: "test-0".to_string(),
+            total_checkers: 1,
             ..Default::default()
         };
         let test_partitions: HashSet<u16> = vec![0, 1].into_iter().collect();
@@ -384,14 +407,13 @@ mod tests {
         manager.update_partitions(&test_partitions);
         let shutdown = CancellationToken::new();
 
-        (config, test_partitions, conn, partitions, manager, shutdown)
+        (config, conn, partitions, manager, shutdown)
     }
 
     #[redis_test(start_paused = false)]
     async fn test_redis_config_provider_load_no_configs() {
-        let (config, test_partitions, _, _, manager, shutdown) = setup_test().await;
-        let _handle =
-            run_config_provider(&config, manager.clone(), test_partitions, shutdown.clone());
+        let (config, _, _, manager, shutdown) = setup_test().await;
+        let _handle = run_config_provider(&config, manager.clone(), shutdown.clone());
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Verify partitions were created but are empty
@@ -410,7 +432,7 @@ mod tests {
 
     #[redis_test(start_paused = false)]
     async fn test_redis_config_provider_load() {
-        let (config, test_partitions, mut conn, partitions, manager, shutdown) = setup_test().await;
+        let (config, mut conn, partitions, manager, shutdown) = setup_test().await;
         let partition_configs = partitions
             .iter()
             .map(|p| {
@@ -436,8 +458,7 @@ mod tests {
                 .unwrap();
         }
 
-        let _handle =
-            run_config_provider(&config, manager.clone(), test_partitions, shutdown.clone());
+        let _handle = run_config_provider(&config, manager.clone(), shutdown.clone());
 
         tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -497,10 +518,9 @@ mod tests {
 
     #[redis_test(start_paused = false)]
     async fn test_redis_config_provider_updates() {
-        let (config, test_partitions, conn, partitions, manager, shutdown) = setup_test().await;
+        let (config, conn, partitions, manager, shutdown) = setup_test().await;
 
-        let _handle =
-            run_config_provider(&config, manager.clone(), test_partitions, shutdown.clone());
+        let _handle = run_config_provider(&config, manager.clone(), shutdown.clone());
 
         tokio::time::sleep(Duration::from_millis(30)).await;
 
@@ -563,4 +583,60 @@ mod tests {
 
         shutdown.cancel();
     }
+
+    fn run_determine_owned_partition_test(
+        total_partitions: u16,
+        checker_id: &str,
+        total_pods: u16,
+        expected_partitions: Vec<u16>,
+    ) {
+        let config = Config {
+            config_provider_redis_total_partitions: total_partitions,
+            checker_id: checker_id.to_string(),
+            total_checkers: total_pods,
+            ..Default::default()
+        };
+        assert_eq!(
+            determine_owned_partitions(&config),
+            expected_partitions.into_iter().collect()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_determine_owned_partitions() {
+        run_determine_owned_partition_test(2, "test-0", 1, vec![0, 1]);
+        run_determine_owned_partition_test(2, "test-0", 2, vec![0]);
+        run_determine_owned_partition_test(2, "test-1", 2, vec![1]);
+        run_determine_owned_partition_test(
+            100,
+            "test-1",
+            10,
+            vec![1, 11, 21, 31, 41, 51, 61, 71, 81, 91],
+        );
+        run_determine_owned_partition_test(
+            100,
+            "test-9",
+            10,
+            vec![9, 19, 29, 39, 49, 59, 69, 79, 89, 99],
+        );
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "checker_number 1 must be less than total_checkers 1")]
+    async fn test_determine_owned_partitions_checker_number_too_high() {
+        run_determine_owned_partition_test(2, "test-1", 1, vec![0, 1]);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "checker_id does not contain a valid checker_number")]
+    async fn test_determine_owned_partitions_no_number() {
+        run_determine_owned_partition_test(2, "test", 1, vec![0, 1]);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "checker_id does not contain a valid checker_number")]
+    async fn test_determine_owned_partitions_invalid() {
+        run_determine_owned_partition_test(2, "test-a", 1, vec![0, 1]);
+    }
+
 }

--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -347,7 +347,7 @@ pub fn determine_owned_partitions(config: &Config) -> HashSet<u16> {
         .last()
         .expect("checker_id should be in format <name>-<checker_number>")
         .parse()
-        .expect("checker_id does not contain a valid checker_number");
+        .expect("checker_id should contain a valid checker_number");
     if checker_number >= config.total_checkers {
         panic!(
             "checker_number {} must be less than total_checkers {}",


### PR DESCRIPTION
This adds `determine_owned_partitions`, which produces a set of partition numbers that this checker owns based on total checkers, total partitions and this checker's checker number.

Simplifies the interface to calling run_config_provider since we can determine partitions via config rather than passing in.