### PR TITLE
feat: add vector result producer

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -100,6 +100,9 @@ pub struct Config {
     /// The batch size to use for vector producer
     pub vector_batch_size: usize,
 
+    /// The vector endpoint to send results to
+    pub vector_endpoint: String,
+
     /// The general purpose redis node to use with this service
     pub redis_host: String,
 
@@ -136,6 +139,7 @@ impl Default for Config {
             configs_kafka_topic: "uptime-configs".to_owned(),
             config_provider_mode: ConfigProviderMode::Kafka,
             vector_batch_size: 10,
+            vector_endpoint: "http://localhost:8020".to_owned(),
             producer_mode: ProducerMode::Kafka,
             config_provider_redis_update_ms: 1000,
             config_provider_redis_total_partitions: 128,
@@ -263,6 +267,7 @@ mod tests {
                         total_checkers: 1,
                         producer_mode: ProducerMode::Kafka,
                         vector_batch_size: 10,
+                        vector_endpoint: "http://localhost:8020".to_owned(),
                     }
                 );
             },
@@ -334,6 +339,7 @@ mod tests {
                         total_checkers: 5,
                         producer_mode: ProducerMode::Kafka,
                         vector_batch_size: 10,
+                        vector_endpoint: "http://localhost:8020".to_owned(),
                     }
                 );
             },

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -97,6 +97,9 @@ pub struct Config {
     /// assigned unless we plan a migration process.
     pub config_provider_redis_total_partitions: u16,
 
+    /// The batch size to use for vector producer
+    pub vector_batch_size: usize,
+
     /// The general purpose redis node to use with this service
     pub redis_host: String,
 
@@ -132,6 +135,7 @@ impl Default for Config {
             configs_kafka_cluster: vec![],
             configs_kafka_topic: "uptime-configs".to_owned(),
             config_provider_mode: ConfigProviderMode::Kafka,
+            vector_batch_size: 10,
             producer_mode: ProducerMode::Kafka,
             config_provider_redis_update_ms: 1000,
             config_provider_redis_total_partitions: 128,
@@ -257,6 +261,8 @@ mod tests {
                         allow_internal_ips: false,
                         checker_number: 0,
                         total_checkers: 1,
+                        producer_mode: ProducerMode::Kafka,
+                        vector_batch_size: 10,
                     }
                 );
             },
@@ -326,6 +332,8 @@ mod tests {
                         allow_internal_ips: true,
                         checker_number: 2,
                         total_checkers: 5,
+                        producer_mode: ProducerMode::Kafka,
+                        vector_batch_size: 10,
                     }
                 );
             },

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -157,7 +157,10 @@ mod tests {
     use figment::Jail;
     use similar_asserts::assert_eq;
 
-    use crate::{app::{cli, config::ProducerMode}, logging};
+    use crate::{
+        app::{cli, config::ProducerMode},
+        logging,
+    };
 
     use super::{Config, ConfigProviderMode, MetricsConfig};
 

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -17,6 +17,13 @@ pub enum ConfigProviderMode {
     Kafka,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProducerMode {
+    Kafka,
+    Vector,
+}
+
 #[serde_as]
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 pub struct MetricsConfig {
@@ -79,6 +86,9 @@ pub struct Config {
     /// Which config provider to use to load configs into memory
     pub config_provider_mode: ConfigProviderMode,
 
+    /// which producer to use to send results
+    pub producer_mode: ProducerMode,
+
     /// The general purpose redis node to use with this service
     pub redis_host: String,
 
@@ -107,6 +117,7 @@ impl Default for Config {
             configs_kafka_cluster: vec![],
             configs_kafka_topic: "uptime-configs".to_owned(),
             config_provider_mode: ConfigProviderMode::Kafka,
+            producer_mode: ProducerMode::Vector,
             redis_host: "redis://127.0.0.1:6379".to_owned(),
             region: "default".to_owned(),
             allow_internal_ips: false,
@@ -146,7 +157,7 @@ mod tests {
     use figment::Jail;
     use similar_asserts::assert_eq;
 
-    use crate::{app::cli, logging};
+    use crate::{app::{cli, config::ProducerMode}, logging};
 
     use super::{Config, ConfigProviderMode, MetricsConfig};
 
@@ -195,6 +206,7 @@ mod tests {
                     results_kafka_topic: "uptime-results".to_owned(),
                     configs_kafka_topic: "uptime-configs".to_owned(),
                     config_provider_mode: ConfigProviderMode::Kafka,
+                    producer_mode: ProducerMode::Kafka,
                     redis_host: "redis://127.0.0.1:6379".to_owned(),
                     region: "default".to_owned(),
                     allow_internal_ips: false,
@@ -257,6 +269,7 @@ mod tests {
                     results_kafka_topic: "uptime-results".to_owned(),
                     configs_kafka_topic: "uptime-configs".to_owned(),
                     config_provider_mode: ConfigProviderMode::Kafka,
+                    producer_mode: ProducerMode::Kafka,
                     redis_host: "10.0.0.3:6379".to_owned(),
                     region: "us-west".to_owned(),
                     allow_internal_ips: true,

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -117,7 +117,7 @@ impl Default for Config {
             configs_kafka_cluster: vec![],
             configs_kafka_topic: "uptime-configs".to_owned(),
             config_provider_mode: ConfigProviderMode::Kafka,
-            producer_mode: ProducerMode::Vector,
+            producer_mode: ProducerMode::Kafka,
             redis_host: "redis://127.0.0.1:6379".to_owned(),
             region: "default".to_owned(),
             allow_internal_ips: false,

--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -252,7 +252,7 @@ mod tests {
     use super::*;
     use crate::{
         checker::dummy_checker::DummyChecker,
-        producer::{dummy_producer::DummyResultsProducer, vector_producer::VectorResultsProducer},
+        producer::{dummy_producer::DummyResultsProducer},
         types::check_config::CheckInterval,
     };
 

--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -251,8 +251,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        checker::dummy_checker::DummyChecker,
-        producer::dummy_producer::DummyResultsProducer,
+        checker::dummy_checker::DummyChecker, producer::dummy_producer::DummyResultsProducer,
         types::check_config::CheckInterval,
     };
 

--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -252,7 +252,7 @@ mod tests {
     use super::*;
     use crate::{
         checker::dummy_checker::DummyChecker,
-        producer::{dummy_producer::DummyResultsProducer},
+        producer::dummy_producer::DummyResultsProducer,
         types::check_config::CheckInterval,
     };
 

--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -251,7 +251,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        checker::dummy_checker::DummyChecker, producer::dummy_producer::DummyResultsProducer,
+        checker::dummy_checker::DummyChecker,
+        producer::{dummy_producer::DummyResultsProducer, vector_producer::VectorResultsProducer},
         types::check_config::CheckInterval,
     };
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -6,9 +6,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, RwLock},
 };
-use tokio::sync::{
-    mpsc::{self, UnboundedSender},
-};
+use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
@@ -116,7 +114,7 @@ impl Manager {
             match &config.producer_mode {
                 ProducerMode::Vector => {
                     let (results_producer, results_worker) =
-                        VectorResultsProducer::new(&config.results_kafka_topic);
+                        VectorResultsProducer::new(&config.results_kafka_topic, config.vector_batch_size);
                     // XXX: Executor will shutdown once the sender goes out of scope. This will happen once all
                     // referneces of the Sender (executor_sender) are dropped.
                     let (executor_sender, executor_handle) = run_executor(

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -116,6 +116,8 @@ impl Manager {
                 ProducerMode::Vector => {
                     let (results_producer, results_worker) =
                         VectorResultsProducer::new(&config.results_kafka_topic);
+                    // XXX: Executor will shutdown once the sender goes out of scope. This will happen once all
+                    // referneces of the Sender (executor_sender) are dropped.
                     let (executor_sender, executor_handle) = run_executor(
                         config.checker_concurrency,
                         checker.clone(),
@@ -138,6 +140,8 @@ impl Manager {
                         &config.results_kafka_topic,
                         kafka_config,
                     ));
+                    // XXX: Executor will shutdown once the sender goes out of scope. This will happen once all
+                    // referneces of the Sender (executor_sender) are dropped.
                     let (sender, handle) = run_executor(
                         config.checker_concurrency,
                         checker.clone(),

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -115,6 +115,7 @@ impl Manager {
             ProducerMode::Vector => {
                 let (results_producer, results_worker) = VectorResultsProducer::new(
                     &config.results_kafka_topic,
+                    config.vector_endpoint.clone(),
                     config.vector_batch_size,
                 );
                 // XXX: Executor will shutdown once the sender goes out of scope. This will happen once all

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1,5 +1,6 @@
 pub mod dummy_producer;
 pub mod kafka_producer;
+pub mod vector_producer;
 
 use sentry_kafka_schemas::SchemaError;
 
@@ -15,8 +16,13 @@ pub enum ExtractCodeError {
     Producer(#[from] ProducerError),
     #[error(transparent)]
     Schema(#[from] SchemaError),
+    #[error(transparent)]
+    VectorRequestError(#[from] reqwest::Error),
+    #[error("Vector request failed with status: {0}")]
+    VectorRequestStatusError(reqwest::StatusCode),
 }
 
 pub trait ResultsProducer: Send + Sync {
     fn produce_checker_result(&self, result: &CheckResult) -> Result<(), ExtractCodeError>;
+ 
 }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -24,5 +24,4 @@ pub enum ExtractCodeError {
 
 pub trait ResultsProducer: Send + Sync {
     fn produce_checker_result(&self, result: &CheckResult) -> Result<(), ExtractCodeError>;
- 
 }

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -1,0 +1,167 @@
+use crate::producer::{ExtractCodeError, ResultsProducer};
+use crate::types::result::CheckResult;
+use reqwest::Client;
+use sentry_kafka_schemas::Schema;
+
+pub struct VectorResultsProducer {
+    schema: Schema,
+    client: Client,
+    endpoint: String,
+}
+
+impl VectorResultsProducer {
+    pub fn new(topic_name: &str) -> Self {
+        let schema = sentry_kafka_schemas::get_schema(topic_name, None).unwrap();
+        let client = Client::new();
+        Self { 
+            schema, 
+            client,
+            endpoint: "http://localhost:8020".to_string()
+        }
+    }
+}
+
+
+
+impl ResultsProducer for VectorResultsProducer {
+    fn produce_checker_result(&self, result: &CheckResult) -> Result<(), ExtractCodeError> {
+        let json = serde_json::to_vec(result)?;
+        self.schema.validate_json(&json)?;
+        
+        // Spawn a tokio task to make the async request
+        let client = self.client.clone();
+        let endpoint = self.endpoint.clone();
+
+        tokio::spawn(async move {
+            // Make POST request to Vector
+            let response = client
+                .post(&endpoint)
+                .body(json)
+                .send()
+                .await
+                .map_err(ExtractCodeError::VectorRequestError)?;
+
+            if !response.status().is_success() {
+                return Err(ExtractCodeError::VectorRequestStatusError(response.status()));
+            }
+
+            Ok(())
+        });
+
+        Ok(())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::VectorResultsProducer;
+    use crate::{
+        producer::ResultsProducer,
+        types::{
+            result::{
+                CheckResult, CheckStatus, CheckStatusReason, CheckStatusReasonType, RequestInfo,
+            },
+            shared::RequestMethod,
+        },
+    };
+    use chrono::{TimeDelta, Utc};
+    use sentry::protocol::SpanId;
+    use uuid::{uuid, Uuid};
+    use httpmock::prelude::*;
+    use httpmock::Method;
+
+ 
+    #[tokio::test]
+    async fn test() {
+        // Start a mock server
+        let mock_server = MockServer::start();
+
+        // Create expected result to compare against
+        let expected_result = CheckResult {
+            guid: Uuid::new_v4(),
+            subscription_id: uuid!("23d6048d67c948d9a19c0b47979e9a03"),
+            status: CheckStatus::Success,
+            status_reason: Some(CheckStatusReason {
+                status_type: CheckStatusReasonType::DnsError,
+                description: "hi".to_string(),
+            }),
+            trace_id: Uuid::new_v4(),
+            span_id: SpanId::default(),
+            scheduled_check_time: Utc::now(),
+            actual_check_time: Utc::now(),
+            duration: Some(TimeDelta::seconds(1)),
+            request_info: Some(RequestInfo {
+                request_type: RequestMethod::Get,
+                http_status_code: Some(200),
+            }),
+            region: "us-west-1".to_string(),
+        };
+        let json = serde_json::to_value(&expected_result).unwrap();
+        let get_mock = mock_server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/")
+                .json_body(json);
+            then.status(200);
+        });
+
+        let mut producer = VectorResultsProducer::new("uptime-results");
+        producer.endpoint = mock_server.url("/");
+
+        let result = producer.produce_checker_result(&expected_result);
+        assert!(result.is_ok());
+
+        // Give the async task time to complete
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        
+        get_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_server_error() {
+        // Start a mock server
+        let mock_server = MockServer::start();
+
+        // Create test result
+        let test_result = CheckResult {
+            guid: Uuid::new_v4(),
+            subscription_id: uuid!("23d6048d67c948d9a19c0b47979e9a03"),
+            status: CheckStatus::Success,
+            status_reason: Some(CheckStatusReason {
+                status_type: CheckStatusReasonType::DnsError,
+                description: "test error".to_string(),
+            }),
+            trace_id: Uuid::new_v4(),
+            span_id: SpanId::default(),
+            scheduled_check_time: Utc::now(),
+            actual_check_time: Utc::now(),
+            duration: Some(TimeDelta::seconds(1)),
+            request_info: Some(RequestInfo {
+                request_type: RequestMethod::Get,
+                http_status_code: Some(200),
+            }),
+            region: "us-west-1".to_string(),
+        };
+
+        // Mock server returns 500 error
+        let error_mock = mock_server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/");
+            then.status(500)
+                .body("Internal Server Error");
+        });
+
+        let mut producer = VectorResultsProducer::new("uptime-results");
+        producer.endpoint = mock_server.url("/");
+
+        let result = producer.produce_checker_result(&test_result);
+        
+        // The initial result should be Ok since the error happens in the spawned task
+        assert!(result.is_ok());
+
+        // Give the async task time to complete
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        
+        error_mock.assert();
+    }
+}

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio::sync::oneshot;
 
-const VECTOR_BATCH_SIZE: usize = 10;
+const VECTOR_BATCH_SIZE: usize = 2;
 
 pub struct VectorResultsProducer {
     schema: Schema,
@@ -74,7 +74,7 @@ impl VectorResultsProducer {
                                     tracing::debug!("Sending request to Vector with body size {}", body.len());
                                     if let Err(e) = client
                                         .post(&endpoint)
-                                        .header("Content-Type", "application/x-ndjson")
+                                        .header("Content-Type", "application/json")
                                         .body(body)
                                         .send()
                                         .await
@@ -109,7 +109,7 @@ impl VectorResultsProducer {
                 tracing::debug!("Sending final request to Vector with body size {}", body.len());
                 if let Err(e) = client
                     .post(&endpoint)
-                    .header("Content-Type", "application/x-ndjson")
+                    .header("Content-Type", "application/json")
                     .body(body)
                     .send()
                     .await
@@ -210,7 +210,7 @@ mod tests {
         let mock = mock_server.mock(|when, then| {
             when.method(Method::POST)
                 .path("/")
-                .header("Content-Type", "application/x-ndjson")
+                .header("Content-Type", "application/json")
                 .matches(|req| {
                     if let Some(body) = &req.body {
                         tracing::debug!("Received request body: {:?}", String::from_utf8_lossy(body));
@@ -301,7 +301,7 @@ mod tests {
         let error_mock = mock_server.mock(|when, then| {
             when.method(Method::POST)
                 .path("/")
-                .header("Content-Type", "application/x-ndjson")
+                .header("Content-Type", "application/json")
                 .matches(|req| {
                     if let Some(body) = &req.body {
                         tracing::debug!("Received request body: {:?}", String::from_utf8_lossy(body));
@@ -310,7 +310,7 @@ mod tests {
                             tracing::debug!("Expected 1 line, got {}", lines.len());
                             return false;
                         }
-                        if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&lines[0]) {
+                        if let Ok(value) = serde_json::from_slice::<serde_json::Value>(lines[0]) {
                             return value["subscription_id"] == "23d6048d67c948d9a19c0b47979e9a03"
                                 && value["status"] == "success"
                                 && value["region"] == "us-west-1";

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -47,7 +47,7 @@ impl VectorResultsProducer {
                 tracing::debug!("event.received_with_size_{}", json.len());
                 batch.push(json);
                 tracing::debug!("batch.size.updated_to_{}", batch.len());
-                
+
                 if batch.len() < vector_batch_size {
                     continue;
                 }

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -4,11 +4,15 @@ use reqwest::Client;
 use sentry_kafka_schemas::Schema;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
+use tokio::sync::oneshot;
+
+const BATCH_SIZE: usize = 2;
 
 pub struct VectorResultsProducer {
     schema: Schema,
     sender: UnboundedSender<Vec<u8>>,
-    _worker: JoinHandle<()>,
+    shutdown_sender: Option<oneshot::Sender<()>>,
+    worker: Option<JoinHandle<()>>,
 }
 
 impl VectorResultsProducer {
@@ -21,31 +25,120 @@ impl VectorResultsProducer {
         let client = Client::new();
         
         let (sender, receiver) = mpsc::unbounded_channel();
-        let worker = Self::spawn_worker(client, endpoint, receiver);
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let worker = Self::spawn_worker(client, endpoint, receiver, shutdown_receiver);
 
         Self { 
             schema,
             sender,
-            _worker: worker,
+            shutdown_sender: Some(shutdown_sender),
+            worker: Some(worker),
         }
     }
 
-    fn spawn_worker(client: Client, endpoint: String, mut receiver: UnboundedReceiver<Vec<u8>>) -> JoinHandle<()> {
+    fn spawn_worker(
+        client: Client, 
+        endpoint: String, 
+        mut receiver: UnboundedReceiver<Vec<u8>>,
+        mut shutdown_receiver: oneshot::Receiver<()>,
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
-            while let Some(json) = receiver.recv().await {
-                // Make POST request to Vector
+            tracing::debug!("Vector producer worker started with endpoint {}", endpoint);
+            let mut batch = Vec::with_capacity(BATCH_SIZE);
+            
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_receiver => {
+                        tracing::debug!("Received shutdown signal");
+                        break;
+                    }
+                    msg = receiver.recv() => {
+                        match msg {
+                            Some(json) => {
+                                tracing::debug!("Received event of size {}", json.len());
+                                batch.push(json);
+                                tracing::debug!("Current batch size: {}", batch.len());
+                                
+                                // Send batch when it reaches BATCH_SIZE
+                                if batch.len() >= BATCH_SIZE {
+                                    tracing::debug!("Sending batch of {} events", batch.len());
+                                    // Convert each JSON bytes to string and ensure each line ends with a newline
+                                    let body = batch.iter()
+                                        .filter_map(|json| String::from_utf8(json.clone()).ok())
+                                        .map(|s| s + "\n")
+                                        .collect::<String>();
+                                    
+                                    // Log the exact payload for debugging
+                                    tracing::debug!("Payload being sent:\n{}", body);
+                                    
+                                    tracing::debug!("Sending request to Vector with body size {}", body.len());
+                                    if let Err(e) = client
+                                        .post(&endpoint)
+                                        .header("Content-Type", "application/x-ndjson")
+                                        .body(body)
+                                        .send()
+                                        .await
+                                    {
+                                        tracing::error!(error = ?e, "Failed to send batch request to Vector");
+                                    } else {
+                                        tracing::debug!("Successfully sent batch request");
+                                    }
+                                    batch.clear();
+                                }
+                            }
+                            None => {
+                                tracing::debug!("Channel closed");
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            
+            // Send any remaining events in the batch
+            if !batch.is_empty() {
+                tracing::debug!("Sending final batch of {} events", batch.len());
+                let body = batch.iter()
+                    .filter_map(|json| String::from_utf8(json.clone()).ok())
+                    .collect::<Vec<String>>()
+                    .join("\n");
+                
+                // Log the exact payload for debugging
+                tracing::debug!("Final payload being sent:\n{}", body);
+                
+                tracing::debug!("Sending final request to Vector with body size {}", body.len());
                 if let Err(e) = client
                     .post(&endpoint)
-                    .body(json)
+                    .header("Content-Type", "application/x-ndjson")
+                    .body(body)
                     .send()
                     .await
                 {
-                    tracing::error!(error = ?e, "Failed to send request to Vector");
-                    continue;
+                    tracing::error!(error = ?e, "Failed to send final batch request to Vector");
+                } else {
+                    tracing::debug!("Successfully sent final batch request");
                 }
             }
+            
             tracing::info!("Vector producer worker shutting down");
         })
+    }
+
+    pub async fn shutdown(&mut self) {
+        if let Some(sender) = self.shutdown_sender.take() {
+            let _ = sender.send(());
+            if let Some(worker) = self.worker.take() {
+                let _ = worker.await;
+            }
+        }
+    }
+}
+
+impl Drop for VectorResultsProducer {
+    fn drop(&mut self) {
+        if let Some(sender) = self.shutdown_sender.take() {
+            let _ = sender.send(());
+        }
     }
 }
 
@@ -68,7 +161,7 @@ impl ResultsProducer for VectorResultsProducer {
 
 #[cfg(test)]
 mod tests {
-    use super::VectorResultsProducer;
+    use super::{VectorResultsProducer, BATCH_SIZE};
     use crate::{
         producer::ResultsProducer,
         types::{
@@ -86,13 +179,8 @@ mod tests {
     use tokio::time::sleep;
     use std::time::Duration;
 
-    #[tokio::test]
-    async fn test() {
-        // Start a mock server
-        let mock_server = MockServer::start();
-
-        // Create expected result to compare against
-        let expected_result = CheckResult {
+    fn create_test_result() -> CheckResult {
+        CheckResult {
             guid: Uuid::new_v4(),
             subscription_id: uuid!("23d6048d67c948d9a19c0b47979e9a03"),
             status: CheckStatus::Success,
@@ -110,66 +198,137 @@ mod tests {
                 http_status_code: Some(200),
             }),
             region: "us-west-1".to_string(),
-        };
-        let json = serde_json::to_value(&expected_result).unwrap();
-        let get_mock = mock_server.mock(|when, then| {
+        }
+    }
+
+    #[tokio::test]
+    async fn test_single_event() {
+        let mock_server = MockServer::start();
+        tracing::debug!("Mock server started at {}", mock_server.url("/"));
+        let test_result = create_test_result();
+        
+        let mock = mock_server.mock(|when, then| {
             when.method(Method::POST)
                 .path("/")
-                .json_body(json);
+                .header("Content-Type", "application/x-ndjson")
+                .matches(|req| {
+                    if let Some(body) = &req.body {
+                        tracing::debug!("Received request body: {:?}", String::from_utf8_lossy(body));
+                        let lines: Vec<_> = body.split(|&b| b == b'\n').filter(|l| !l.is_empty()).collect();
+                        if lines.len() != 1 {
+                            tracing::debug!("Expected 1 line, got {}", lines.len());
+                            return false;
+                        }
+                        if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&lines[0]) {
+                            return value["subscription_id"] == "23d6048d67c948d9a19c0b47979e9a03"
+                                && value["status"] == "success"
+                                && value["region"] == "us-west-1";
+                        }
+                    }
+                    false
+                });
             then.status(200);
         });
 
-        let producer = VectorResultsProducer::new_with_endpoint("uptime-results", mock_server.url("/"));
-        let result = producer.produce_checker_result(&expected_result);
+        let mut producer = VectorResultsProducer::new_with_endpoint("uptime-results", mock_server.url("/"));
+        let result = producer.produce_checker_result(&test_result);
         assert!(result.is_ok());
 
-        // Give the worker task time to process the message
+        // Wait a bit and then shut down
         sleep(Duration::from_millis(100)).await;
+        producer.shutdown().await;
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_batch_events() {
+        let mock_server = MockServer::start();
+        tracing::debug!("Mock server started at {}", mock_server.url("/"));
+        let mut producer = VectorResultsProducer::new_with_endpoint("uptime-results", mock_server.url("/"));
         
-        get_mock.assert();
+        // Create and send BATCH_SIZE + 2 events
+        for i in 0..(BATCH_SIZE + 2) {
+            tracing::debug!("Sending event {}", i + 1);
+            let test_result = create_test_result();
+            let result = producer.produce_checker_result(&test_result);
+            assert!(result.is_ok());
+        }
+
+        // Mock for full batch and remainder
+        let mock = mock_server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/")
+                .header("Content-Type", "application/json")
+                .matches(|req| {
+                    if let Some(body) = &req.body {
+                        tracing::debug!("Received request body: {:?}", String::from_utf8_lossy(body));
+                        let lines: Vec<_> = body.split(|&b| b == b'\n').filter(|l| !l.is_empty()).collect();
+                        let len = lines.len();
+                        if len != BATCH_SIZE && len != 2 {
+                            tracing::debug!("Expected {} or 2 lines, got {}", BATCH_SIZE, len);
+                            return false;
+                        }
+                        // Verify each line is valid JSON with expected fields
+                        lines.iter().all(|line| {
+                            if let Ok(value) = serde_json::from_slice::<serde_json::Value>(line) {
+                                return value["subscription_id"] == "23d6048d67c948d9a19c0b47979e9a03"
+                                    && value["status"] == "success"
+                                    && value["region"] == "us-west-1";
+                            }
+                            false
+                        })
+                    } else {
+                        false
+                    }
+                });
+            then.status(200);
+        });
+
+        // Wait a bit and then shut down
+        sleep(Duration::from_millis(100)).await;
+        producer.shutdown().await;
+        
+        // We expect 2 requests: one with BATCH_SIZE events and one with 2 events
+        mock.assert_hits(2);
     }
 
     #[tokio::test]
     async fn test_server_error() {
-        // Start a mock server
         let mock_server = MockServer::start();
+        tracing::debug!("Mock server started at {}", mock_server.url("/"));
+        let test_result = create_test_result();
 
-        // Create test result
-        let test_result = CheckResult {
-            guid: Uuid::new_v4(),
-            subscription_id: uuid!("23d6048d67c948d9a19c0b47979e9a03"),
-            status: CheckStatus::Success,
-            status_reason: Some(CheckStatusReason {
-                status_type: CheckStatusReasonType::DnsError,
-                description: "test error".to_string(),
-            }),
-            trace_id: Uuid::new_v4(),
-            span_id: SpanId::default(),
-            scheduled_check_time: Utc::now(),
-            actual_check_time: Utc::now(),
-            duration: Some(TimeDelta::seconds(1)),
-            request_info: Some(RequestInfo {
-                request_type: RequestMethod::Get,
-                http_status_code: Some(200),
-            }),
-            region: "us-west-1".to_string(),
-        };
-
-        // Mock server returns 500 error
         let error_mock = mock_server.mock(|when, then| {
             when.method(Method::POST)
-                .path("/");
+                .path("/")
+                .header("Content-Type", "application/x-ndjson")
+                .matches(|req| {
+                    if let Some(body) = &req.body {
+                        tracing::debug!("Received request body: {:?}", String::from_utf8_lossy(body));
+                        let lines: Vec<_> = body.split(|&b| b == b'\n').filter(|l| !l.is_empty()).collect();
+                        if lines.len() != 1 {
+                            tracing::debug!("Expected 1 line, got {}", lines.len());
+                            return false;
+                        }
+                        if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&lines[0]) {
+                            return value["subscription_id"] == "23d6048d67c948d9a19c0b47979e9a03"
+                                && value["status"] == "success"
+                                && value["region"] == "us-west-1";
+                        }
+                    }
+                    false
+                });
             then.status(500)
                 .body("Internal Server Error");
         });
 
-        let producer = VectorResultsProducer::new_with_endpoint("uptime-results", mock_server.url("/"));
+        let mut producer = VectorResultsProducer::new_with_endpoint("uptime-results", mock_server.url("/"));
         let result = producer.produce_checker_result(&test_result);
         assert!(result.is_ok());
 
-        // Give the worker task time to process the message
+        // Wait a bit and then shut down
         sleep(Duration::from_millis(100)).await;
-        
+        producer.shutdown().await;
         error_mock.assert();
     }
 }

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -89,10 +89,7 @@ impl VectorResultsProducer {
                 // Log the exact payload for debugging
                 tracing::debug!("final_payload.sending\n{}", body);
 
-                tracing::debug!(
-                    "final_request.sending_to_vector_with_size_{}",
-                    body.len()
-                );
+                tracing::debug!("final_request.sending_to_vector_with_size_{}", body.len());
                 if let Err(e) = client
                     .post(&endpoint)
                     .header("Content-Type", "application/json")
@@ -110,7 +107,6 @@ impl VectorResultsProducer {
         })
     }
 }
-
 
 impl ResultsProducer for VectorResultsProducer {
     fn produce_checker_result(&self, result: &CheckResult) -> Result<(), ExtractCodeError> {

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -11,15 +11,7 @@ pub struct VectorResultsProducer {
 }
 
 impl VectorResultsProducer {
-    pub fn new(topic_name: &str, vector_batch_size: usize) -> (Self, JoinHandle<()>) {
-        Self::new_with_endpoint(
-            topic_name,
-            "http://localhost:8020".to_string(),
-            vector_batch_size,
-        )
-    }
-
-    pub fn new_with_endpoint(
+    pub fn new(
         topic_name: &str,
         endpoint: String,
         vector_batch_size: usize,
@@ -211,7 +203,7 @@ mod tests {
         });
 
         let (producer, worker) =
-            VectorResultsProducer::new_with_endpoint("uptime-results", mock_server.url("/"), 10);
+            VectorResultsProducer::new("uptime-results", mock_server.url("/").to_string(), 10);
         let result = producer.produce_checker_result(&test_result);
         assert!(result.is_ok());
 
@@ -230,9 +222,9 @@ mod tests {
     async fn test_batch_events() {
         let mock_server = MockServer::start();
         tracing::debug!("Mock server started at {}", mock_server.url("/"));
-        let (producer, worker) = VectorResultsProducer::new_with_endpoint(
+        let (producer, worker) = VectorResultsProducer::new(
             "uptime-results",
-            mock_server.url("/"),
+            mock_server.url("/").to_string(),
             TEST_BATCH_SIZE,
         );
 
@@ -329,9 +321,9 @@ mod tests {
             then.status(500).body("Internal Server Error");
         });
 
-        let (producer, worker) = VectorResultsProducer::new_with_endpoint(
+        let (producer, worker) = VectorResultsProducer::new(
             "uptime-results",
-            mock_server.url("/"),
+            mock_server.url("/").to_string(),
             TEST_BATCH_SIZE,
         );
         let result = producer.produce_checker_result(&test_result);
@@ -383,9 +375,9 @@ mod tests {
             then.status(200);
         });
 
-        let (producer, worker) = VectorResultsProducer::new_with_endpoint(
+        let (producer, worker) = VectorResultsProducer::new(
             "uptime-results",
-            mock_server.url("/"),
+            mock_server.url("/").to_string(),
             TEST_BATCH_SIZE,
         );
 


### PR DESCRIPTION
- [x] adds a new producer type, `VectorProducer`. This producer opens a channel and creates a background worker which will send check results to vector's http interface in batches, and does a final flush of all results when shut down. (TODO: make batch size configurable).
- [x] allow for configuration of producer
- [x] manage vector producer join handler in manage. this part is quite messy right now, and could use some help cleaning it up.

TODO: handle failure modes, determine how to handle if/when vector goes down (should we cap the size of the channel?)