### PR TITLE
feat(uptime): add new failure types

### DIFF
--- a/Dockerfile.localdev
+++ b/Dockerfile.localdev
@@ -30,6 +30,7 @@ WORKDIR /app
 RUN mkdir -p /app/src
 VOLUME /app/src
 COPY src /app/src
+COPY redis-test-macro /app/redis-test-macro
 
 # Just copy the Cargo.toml files and trigger a build so that we compile our
 # dependencies only. This way we avoid layer cache invalidation if our

--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -213,6 +213,8 @@ fn record_result_metrics(result: &CheckResult) {
         Some(CheckStatusReasonType::Failure) => Some("failure"),
         Some(CheckStatusReasonType::DnsError) => Some("dns_error"),
         Some(CheckStatusReasonType::Timeout) => Some("timeout"),
+        Some(CheckStatusReasonType::TlsError) => Some("tls_error"),
+        Some(CheckStatusReasonType::ConnectionError) => Some("connection_error"),
         None => None,
     };
     let status_code = match request_info.as_ref().and_then(|a| a.http_status_code) {

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -669,7 +669,7 @@ mod tests {
             );
             assert_eq!(
                 result.status_reason.as_ref().map(|r| r.status_type),
-                Some(CheckStatusReasonType::Failure),
+                Some(CheckStatusReasonType::TlsError),
                 "Test case: {:?}",
                 cert_type
             );
@@ -697,7 +697,7 @@ mod tests {
         assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
         assert_eq!(
             result.status_reason.as_ref().map(|r| r.status_type),
-            Some(CheckStatusReasonType::Failure)
+            Some(CheckStatusReasonType::ConnectionError)
         );
         assert_eq!(
             result.status_reason.map(|r| r.description),
@@ -735,7 +735,7 @@ mod tests {
         assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
         assert_eq!(
             result.status_reason.as_ref().map(|r| r.status_type),
-            Some(CheckStatusReasonType::Failure)
+            Some(CheckStatusReasonType::ConnectionError)
         );
         let result_description = result.status_reason.map(|r| r.description).unwrap();
         assert_eq!(

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -124,7 +124,10 @@ fn hyper_error(err: &reqwest::Error) -> Option<(CheckStatusReasonType, String)> 
     while let Some(source) = inner.source() {
         if let Some(hyper_error) = source.downcast_ref::<hyper::Error>() {
             if hyper_error.is_incomplete_message() {
-                return Some((CheckStatusReasonType::ConnectionError, hyper_error.to_string()));
+                return Some((
+                    CheckStatusReasonType::ConnectionError,
+                    hyper_error.to_string(),
+                ));
             }
             return Some((CheckStatusReasonType::Failure, hyper_error.to_string()));
         }

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -242,7 +242,7 @@ impl Checker for HttpChecker {
                     }
                 } else {
                     // if any error falls through we should log it,
-                    // none should be.
+                    // none should fall through.
                     let error_msg = e.without_url();
                     tracing::info!("check_url.error: {:?}", error_msg);
                     CheckStatusReason {

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -237,10 +237,11 @@ impl Checker for HttpChecker {
                 } else {
                     // if any error falls through we should log it,
                     // none should be.
-                    tracing::info!("check_url.error: {:?}", e.without_url());
+                    let error_msg = e.without_url();
+                    tracing::info!("check_url.error: {:?}", error_msg);
                     CheckStatusReason {
                         status_type: CheckStatusReasonType::Failure,
-                        description: format!("{:?}", e.without_url()),
+                        description: format!("{:?}", error_msg),
                     }
                 }
             }),

--- a/src/types/result.rs
+++ b/src/types/result.rs
@@ -29,6 +29,8 @@ pub enum CheckStatus {
 pub enum CheckStatusReasonType {
     Timeout,
     DnsError,
+    TlsError,
+    ConnectionError,
     Failure,
 }
 


### PR DESCRIPTION
- [x] add connection_error and `tls_error` failure types. need https://github.com/getsentry/sentry-kafka-schemas/pull/377 rolled out to sentry and snuba before merging
- [x] log fallthrough errors, as they should not occur, and if we do, we should implement code to catch them.


I also considered making `connection_error` split into `connection_reset` and `connection_refused`. thoughts?