### PR TITLE
dev: faster docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
-/target
-.git
+target/
+.git/
+.gitignore
+.env
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,52 @@
 FROM rust:1.80-alpine3.20 as builder
 
-ARG UPTIME_CHECKER_GIT_REVISION
-ENV UPTIME_CHECKER_GIT_REVISION=$UPTIME_CHECKER_GIT_REVISION
+# Install system dependencies
+RUN apk add --no-cache \
+    libc-dev \
+    cmake \
+    make \
+    g++ \
+    pkgconfig \
+    openssl-dev
 
+# Configure cargo
 RUN mkdir -p ~/.cargo && \
     echo '[registries.crates-io]' > ~/.cargo/config && \
     echo 'protocol = "sparse"' >> ~/.cargo/config
 
-RUN apk add --no-cache libc-dev cmake make g++
-RUN apk add --no-cache pkgconfig openssl-dev
-
-RUN cargo new --bin /app
 WORKDIR /app
 
-# Just copy the Cargo.toml files and trigger a build so that we compile our
-# dependencies only. This way we avoid layer cache invalidation if our
-# dependencies haven't changed, resulting in faster builds.
+# Copy only the files needed for dependency caching
 COPY Cargo.toml Cargo.lock ./
 COPY redis-test-macro redis-test-macro/
 
+# Create a dummy main.rs to build dependencies
+RUN mkdir src && \
+    echo "fn main() {}" > src/main.rs && \
+    # Build dependencies only
+    export RUSTFLAGS="-Ctarget-feature=-crt-static" && \
+    export PKG_CONFIG_ALLOW_CROSS=1 && \
+    cargo build --release && \
+    rm -rf src/
+
+# Set environment variables for the final build
 ENV RUSTFLAGS="-Ctarget-feature=-crt-static"
 ENV PKG_CONFIG_ALLOW_CROSS=1
-RUN cargo build --release && rm -rf src/
+ARG UPTIME_CHECKER_GIT_REVISION
+ENV UPTIME_CHECKER_GIT_REVISION=$UPTIME_CHECKER_GIT_REVISION
 
-# Copy the source code and run the build again. This should only compile the
-# app itself as the dependencies were already built above.
-COPY . ./
-RUN rm target/release/deps/uptime_checker* && cargo build --release
+# Copy the actual source code and build
+COPY . .
+RUN cargo build --release
 
 FROM alpine:3.20
 
 COPY --from=builder /app/target/release/uptime-checker /usr/local/bin/uptime-checker
 
-RUN apk add --no-cache tini libgcc
+RUN apk add --no-cache tini libgcc && \
+    addgroup -S app && \
+    adduser -S app -G app
 
-RUN addgroup -S app && adduser -S app -G app
 USER app
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/uptime-checker"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,13 +9,10 @@ steps:
         'us-central1-docker.pkg.dev/$PROJECT_ID/uptime-checker/image:$COMMIT_SHA',
         '--build-arg',
         'UPTIME_CHECKER_GIT_REVISION=$COMMIT_SHA',
-        '--build-arg',
-        'BUILDKIT_INLINE_CACHE=1',
         '--cache-from',
         'us-central1-docker.pkg.dev/$PROJECT_ID/uptime-checker/image:latest',
         '.',
       ]
-    env: [DOCKER_BUILDKIT=1]
 
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
@@ -29,3 +26,6 @@ steps:
 images: [
   'us-central1-docker.pkg.dev/$PROJECT_ID/uptime-checker/image:$COMMIT_SHA',
 ]
+
+options:
+  machineType: 'E2_HIGHCPU_8'


### PR DESCRIPTION
- [x] cache build dependencies in Dockerfile so we don't have to pull and compile them every time
- [x] better `.dockerignore`
- [x] Docker Buildkit doesn't seem supported on google cloud build, so removed that option
- [x] use a `E2_HIGHCPU_8` machine type to build the images, which should compile things faster