### PR TITLE
chore(uptime): Add config to allow us to configure whether to disable connection re-use

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -112,6 +112,9 @@ pub struct Config {
     /// Allow uptime checks against internal IP addresses
     pub allow_internal_ips: bool,
 
+    /// Whether to disable connection re-use in the http checker
+    pub disable_connection_reuse: bool,
+
     /// The unioque index of this checker out of the total nuimber of checkers. Should be
     /// zero-indexed.
     pub checker_number: u16,
@@ -146,6 +149,7 @@ impl Default for Config {
             redis_host: "redis://127.0.0.1:6379".to_owned(),
             region: "default".to_owned(),
             allow_internal_ips: false,
+            disable_connection_reuse: true,
             checker_number: 0,
             total_checkers: 1,
         }
@@ -263,6 +267,7 @@ mod tests {
                         redis_host: "redis://127.0.0.1:6379".to_owned(),
                         region: "default".to_owned(),
                         allow_internal_ips: false,
+                        disable_connection_reuse: true,
                         checker_number: 0,
                         total_checkers: 1,
                         producer_mode: ProducerMode::Kafka,
@@ -302,6 +307,7 @@ mod tests {
                 ("UPTIME_CHECKER_REDIS_HOST", "10.0.0.3:6379"),
                 ("UPTIME_CHECKER_REGION", "us-west"),
                 ("UPTIME_CHECKER_ALLOW_INTERNAL_IPS", "true"),
+                ("UPTIME_CHECKER_DISABLE_CONNECTION_REUSE", "false"),
                 ("UPTIME_CHECKER_CHECKER_NUMBER", "2"),
                 ("UPTIME_CHECKER_TOTAL_CHECKERS", "5"),
             ],
@@ -335,6 +341,7 @@ mod tests {
                         redis_host: "10.0.0.3:6379".to_owned(),
                         region: "us-west".to_owned(),
                         allow_internal_ips: true,
+                        disable_connection_reuse: false,
                         checker_number: 2,
                         total_checkers: 5,
                         producer_mode: ProducerMode::Kafka,

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -650,6 +650,7 @@ mod tests {
 
         let checker = HttpChecker::new_internal(Options {
             validate_url: false,
+            disable_connection_reuse: true,
         });
         let tick = make_tick();
 
@@ -739,6 +740,8 @@ mod tests {
 
         let checker = HttpChecker::new_internal(Options {
             validate_url: false,
+            disable_connection_reuse: true,
+
         });
         let tick = make_tick();
         let config = CheckConfig {

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -151,7 +151,9 @@ impl HttpChecker {
             builder.pool_max_idle_per_host(0)
         } else {
             builder
-        }.build().expect("Failed to build checker client");
+        }
+        .build()
+        .expect("Failed to build checker client");
 
         Self { client }
     }
@@ -741,7 +743,6 @@ mod tests {
         let checker = HttpChecker::new_internal(Options {
             validate_url: false,
             disable_connection_reuse: true,
-
         });
         let tick = make_tick();
         let config = CheckConfig {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -108,7 +108,10 @@ impl Manager {
     /// The returned shutdown function may be called to stop the consumer and thus shutdown all
     /// PartitionedService's, stopping check execution.
     pub fn start(config: Arc<Config>) -> impl FnOnce() -> Pin<Box<dyn Future<Output = ()>>> {
-        let checker = Arc::new(HttpChecker::new(!config.allow_internal_ips, config.disable_connection_reuse));
+        let checker = Arc::new(HttpChecker::new(
+            !config.allow_internal_ips,
+            config.disable_connection_reuse,
+        ));
 
         let (executor_sender, (executor_join_handle, results_worker)) = match &config.producer_mode
         {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -108,7 +108,7 @@ impl Manager {
     /// The returned shutdown function may be called to stop the consumer and thus shutdown all
     /// PartitionedService's, stopping check execution.
     pub fn start(config: Arc<Config>) -> impl FnOnce() -> Pin<Box<dyn Future<Output = ()>>> {
-        let checker = Arc::new(HttpChecker::new(!config.allow_internal_ips));
+        let checker = Arc::new(HttpChecker::new(!config.allow_internal_ips, config.disable_connection_reuse));
 
         let (executor_sender, (executor_join_handle, results_worker)) = match &config.producer_mode
         {


### PR DESCRIPTION
This might be causing problems with our load test in s4s. Just adding this option so we can disable it there.