### PR TITLE
feat(uptime): Implement redis cluster for config checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1081,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -1098,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -1132,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1143,21 +1149,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2629,19 +2635,22 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.26.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e902a69d09078829137b4a5d9d082e0490393537badd7c91a3d69d14639e115f"
+checksum = "e37ec3fd44bea2ec947ba6cc7634d7999a6590aca7c35827c250bc0de502bda6"
 dependencies = [
  "arc-swap",
- "async-trait",
  "bytes",
  "combine",
+ "crc16",
+ "futures-sink",
  "futures-util",
  "itoa",
+ "log",
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
+ "rand",
  "ryu",
  "sha1_smol",
  "socket2 0.5.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ metrics-exporter-statsd = "0.8.0"
 metrics = "0.23.0"
 futures = "0.3.30"
 tokio-stream = "0.1.15"
-redis = { version = "0.26.0", features = ["tokio-comp"] }
+redis = { version = "0.28.2", features = ["cluster-async", "tokio-comp"] }
 ipnet = "2.10.0"
 hickory-resolver = "0.24.1"
 tokio-rustls = "0.26.1"

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -103,6 +103,9 @@ pub struct Config {
     /// The vector endpoint to send results to
     pub vector_endpoint: String,
 
+    /// Whether we're using redis in standalone or cluster mode
+    pub redis_enable_cluster: bool,
+
     /// The general purpose redis node to use with this service
     pub redis_host: String,
 
@@ -146,6 +149,7 @@ impl Default for Config {
             producer_mode: ProducerMode::Kafka,
             config_provider_redis_update_ms: 1000,
             config_provider_redis_total_partitions: 128,
+            redis_enable_cluster: false,
             redis_host: "redis://127.0.0.1:6379".to_owned(),
             region: "default".to_owned(),
             allow_internal_ips: false,
@@ -264,6 +268,7 @@ mod tests {
                         config_provider_mode: ConfigProviderMode::Kafka,
                         config_provider_redis_update_ms: 1000,
                         config_provider_redis_total_partitions: 128,
+                        redis_enable_cluster: false,
                         redis_host: "redis://127.0.0.1:6379".to_owned(),
                         region: "default".to_owned(),
                         allow_internal_ips: false,
@@ -304,6 +309,7 @@ mod tests {
                     "32",
                 ),
                 ("UPTIME_CHECKER_STATSD_ADDR", "10.0.0.1:1234"),
+                ("UPTIME_CHECKER_REDIS_ENABLE_CLUSTER", "true"),
                 ("UPTIME_CHECKER_REDIS_HOST", "10.0.0.3:6379"),
                 ("UPTIME_CHECKER_REGION", "us-west"),
                 ("UPTIME_CHECKER_ALLOW_INTERNAL_IPS", "true"),
@@ -338,6 +344,7 @@ mod tests {
                         config_provider_mode: ConfigProviderMode::Kafka,
                         config_provider_redis_update_ms: 2000,
                         config_provider_redis_total_partitions: 32,
+                        redis_enable_cluster: true,
                         redis_host: "10.0.0.3:6379".to_owned(),
                         region: "us-west".to_owned(),
                         allow_internal_ips: true,

--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -83,10 +83,7 @@ pub enum RedisAsyncConnection {
 }
 
 impl ConnectionLike for RedisAsyncConnection {
-    fn req_packed_command<'a>(
-        &'a mut self,
-        cmd: &'a Cmd,
-    ) -> RedisFuture<'a, Value> {
+    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
         match self {
             RedisAsyncConnection::Cluster(conn) => Box::pin(conn.req_packed_command(cmd)),
             RedisAsyncConnection::Single(conn) => Box::pin(conn.req_packed_command(cmd)),
@@ -117,13 +114,11 @@ impl ConnectionLike for RedisAsyncConnection {
     }
 }
 
-
 pub struct RedisConfigProvider {
     redis: RedisConnection,
     partitions: HashSet<u16>,
     check_interval: Duration,
 }
-
 
 impl RedisConfigProvider {
     pub fn new(
@@ -448,7 +443,8 @@ mod tests {
         };
         let test_partitions: HashSet<u16> = vec![0, 1].into_iter().collect();
         let client = redis::Client::open(config.redis_host.clone()).unwrap();
-        let mut conn = RedisAsyncConnection::Single(client.get_multiplexed_tokio_connection().await.unwrap());
+        let mut conn =
+            RedisAsyncConnection::Single(client.get_multiplexed_tokio_connection().await.unwrap());
 
         let partitions = RedisConfigProvider::new(
             config.redis_host.as_str(),

--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -69,7 +69,6 @@ impl RedisKey for CheckConfig {
     }
 }
 
-
 pub struct RedisConfigProvider {
     redis: RedisClient,
     partitions: HashSet<u16>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,10 @@ mod logging;
 mod manager;
 mod metrics;
 mod producer;
+mod redis;
 mod scheduler;
 mod test_utils;
 mod types;
-mod redis;
 
 use std::process;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod producer;
 mod scheduler;
 mod test_utils;
 mod types;
+mod redis;
 
 use std::process;
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -65,6 +65,7 @@ impl PartitionedService {
             config.redis_host.clone(),
             config_loaded,
             config.region.clone(),
+            config.redis_enable_cluster,
         );
 
         Self {

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -1,0 +1,68 @@
+use redis::aio::ConnectionLike;
+use redis::{Cmd, Pipeline, RedisFuture, Value};
+use redis::cluster::ClusterClient;
+
+#[derive(Clone)]
+pub enum RedisAsyncConnection {
+    Cluster(redis::cluster_async::ClusterConnection),
+    Single(redis::aio::MultiplexedConnection),
+}
+
+impl ConnectionLike for RedisAsyncConnection {
+    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+        match self {
+            RedisAsyncConnection::Cluster(conn) => Box::pin(conn.req_packed_command(cmd)),
+            RedisAsyncConnection::Single(conn) => Box::pin(conn.req_packed_command(cmd)),
+        }
+    }
+
+    fn req_packed_commands<'a>(
+        &'a mut self,
+        cmd: &'a Pipeline,
+        offset: usize,
+        count: usize,
+    ) -> RedisFuture<'a, Vec<Value>> {
+        match self {
+            RedisAsyncConnection::Cluster(conn) => {
+                Box::pin(conn.req_packed_commands(cmd, offset, count))
+            }
+            RedisAsyncConnection::Single(conn) => {
+                Box::pin(conn.req_packed_commands(cmd, offset, count))
+            }
+        }
+    }
+
+    fn get_db(&self) -> i64 {
+        match self {
+            RedisAsyncConnection::Cluster(conn) => conn.get_db(),
+            RedisAsyncConnection::Single(conn) => conn.get_db(),
+        }
+    }
+}
+
+pub enum RedisClient {
+    Cluster(ClusterClient),
+    Single(redis::Client),
+}
+
+pub fn build_redis_client(redis_url: &str, enable_cluster: bool) -> RedisClient{
+    if enable_cluster {
+        RedisClient::Cluster(ClusterClient::builder(vec![redis_url.to_string()]).build().expect("Failed to build cluster client"))
+    } else {
+        RedisClient::Single(redis::Client::open(redis_url).expect("Failed to open redis client"))
+    }
+}
+
+
+impl RedisClient {
+    pub async fn get_async_connection(&self) -> RedisAsyncConnection {
+        match self {
+            RedisClient::Cluster(client) => RedisAsyncConnection::Cluster(
+                client.get_async_connection().await.expect("Unable to connect to Redis")
+            ),
+            RedisClient::Single(client) => RedisAsyncConnection::Single(
+                client.get_multiplexed_tokio_connection().await.expect("Unable to connect to Redis")
+            ),
+        }
+    }
+}

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -1,6 +1,6 @@
 use redis::aio::ConnectionLike;
-use redis::{Cmd, Pipeline, RedisFuture, Value};
 use redis::cluster::ClusterClient;
+use redis::{Cmd, Pipeline, RedisFuture, Value};
 
 #[derive(Clone)]
 pub enum RedisAsyncConnection {
@@ -45,23 +45,32 @@ pub enum RedisClient {
     Single(redis::Client),
 }
 
-pub fn build_redis_client(redis_url: &str, enable_cluster: bool) -> RedisClient{
+pub fn build_redis_client(redis_url: &str, enable_cluster: bool) -> RedisClient {
     if enable_cluster {
-        RedisClient::Cluster(ClusterClient::builder(vec![redis_url.to_string()]).build().expect("Failed to build cluster client"))
+        RedisClient::Cluster(
+            ClusterClient::builder(vec![redis_url.to_string()])
+                .build()
+                .expect("Failed to build cluster client"),
+        )
     } else {
         RedisClient::Single(redis::Client::open(redis_url).expect("Failed to open redis client"))
     }
 }
 
-
 impl RedisClient {
     pub async fn get_async_connection(&self) -> RedisAsyncConnection {
         match self {
             RedisClient::Cluster(client) => RedisAsyncConnection::Cluster(
-                client.get_async_connection().await.expect("Unable to connect to Redis")
+                client
+                    .get_async_connection()
+                    .await
+                    .expect("Unable to connect to Redis"),
             ),
             RedisClient::Single(client) => RedisAsyncConnection::Single(
-                client.get_multiplexed_tokio_connection().await.expect("Unable to connect to Redis")
+                client
+                    .get_multiplexed_tokio_connection()
+                    .await
+                    .expect("Unable to connect to Redis"),
             ),
         }
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -12,9 +12,8 @@ use tokio_util::sync::CancellationToken;
 use crate::check_executor::{queue_check, CheckSender};
 use crate::config_store::{RwConfigStore, Tick};
 use crate::config_waiter::BootResult;
-use redis::AsyncCommands;
 use crate::redis::build_redis_client;
-
+use redis::AsyncCommands;
 
 #[allow(clippy::too_many_arguments)]
 pub fn run_scheduler(


### PR DESCRIPTION
This implements an option to use the redis cluster client for our redis config provider. Defaults to off for backwards compatibility.