### PR TITLE
fix(uptime): Fix scheduler to better distribute work amongst the regions

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -312,15 +312,20 @@ mod tests {
             .expect("Couldn't save progress of scheduler");
 
         let config_store = Arc::new(ConfigStore::new_rw());
-
+        // We choose the subscription id specifically here. We need the first to be
+        // `<val> % 60 == 1`, and also that the subscription seed id we produce based
+        // on it in `CheckConfig.should_run` is `<val> % active_regions.length() == 0`
+        // so that it's in us_west.
+        // For config 2, we need it to be `<val> % 60 == 3` and
+        // `<val> % active_regions.length() == 1` so that it's in us_east.
         let config1 = Arc::new(CheckConfig {
-            subscription_id: Uuid::from_u128(1),
+            subscription_id: Uuid::from_u128(61),
             active_regions: Some(vec!["us_west".to_string(), "us_east".to_string()]),
             region_schedule_mode: Some(RegionScheduleMode::RoundRobin),
             ..Default::default()
         });
         let config2 = Arc::new(CheckConfig {
-            subscription_id: Uuid::from_u128(3),
+            subscription_id: Uuid::from_u128(63),
             active_regions: Some(vec!["us_east".to_string(), "us_west".to_string()]),
             region_schedule_mode: Some(RegionScheduleMode::RoundRobin),
             ..Default::default()

--- a/src/types/check_config.rs
+++ b/src/types/check_config.rs
@@ -23,6 +23,8 @@ pub enum CheckInterval {
 
 /// The largest check interval
 pub const MAX_CHECK_INTERVAL_SECS: usize = CheckInterval::SixtyMinutes as usize;
+
+/// A random hardcoded id that we use to generated v5 uuids based on subscription ids.
 pub const SUBSCRIPTION_ID_NAMESPACE: Uuid = Uuid::from_u128(31415926535897932384626433832795u128);
 
 /// The CheckConfig represents a configuration for a single check.


### PR DESCRIPTION
Currently, our checkers in each region are either processing all configs, or are processing none. This pr stripes the work better so that it's evenly distributed between regions