### PR TITLE
chore(uptime): Add stat before we filter out skipped region checks

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -92,6 +92,12 @@ async fn scheduler_loop(
         let mut results = vec![];
 
         for config in configs {
+            // Stat to see if the cadence that configs are processed is spiky between regions
+            metrics::counter!(
+                    "scheduler.config_might_run",
+                    "uptime_region" => region.clone(),
+                )
+                .increment(1);
             if config.should_run(tick, &region) {
                 results.push(queue_check(&executor_sender, tick, config));
             } else {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -94,10 +94,10 @@ async fn scheduler_loop(
         for config in configs {
             // Stat to see if the cadence that configs are processed is spiky between regions
             metrics::counter!(
-                    "scheduler.config_might_run",
-                    "uptime_region" => region.clone(),
-                )
-                .increment(1);
+                "scheduler.config_might_run",
+                "uptime_region" => region.clone(),
+            )
+            .increment(1);
             if config.should_run(tick, &region) {
                 results.push(queue_check(&executor_sender, tick, config));
             } else {


### PR DESCRIPTION
We see some weird spikiness in datadog, trying to determine if it's a stats bug or some kind of scheduling problem.