### PR TITLE
fix(uptime): Fix race bug for scheduler progress key

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -178,13 +178,13 @@ async fn scheduler_loop(
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Add;
     use crate::app::config::Config;
     use crate::check_executor::CheckSender;
     use chrono::{Duration, TimeDelta, Utc};
     use redis::{Client, Commands};
     use redis_test_macro::redis_test;
     use similar_asserts::assert_eq;
+    use std::ops::Add;
     use std::sync::Arc;
     use tokio::sync::oneshot;
     use tokio_util::sync::CancellationToken;
@@ -538,7 +538,11 @@ mod tests {
         let _: () = connection
             .set(
                 progress_key.clone(),
-                Utc::now().add(TimeDelta::seconds(60)).timestamp_nanos_opt().unwrap().to_string(),
+                Utc::now()
+                    .add(TimeDelta::seconds(60))
+                    .timestamp_nanos_opt()
+                    .unwrap()
+                    .to_string(),
             )
             .expect("Couldn't save progress of scheduler");
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -64,6 +64,9 @@ async fn scheduler_loop(
         Some(result) => {
             let last_completed_check_nanos: i64 = result.parse().unwrap_or(Utc::now().timestamp());
             let next_check = Utc.timestamp_nanos(last_completed_check_nanos) + tick_frequency;
+            // There's a race where a checker is running for a given progress_key, and another is starting.
+            // Since we add `tick_frequency` to the date here, the date can end up in the future, which causes
+            // a panic when we subtract it from `Utc::now()`. We avoid this by clamping to Utc::now().
             next_check.min(Utc::now().duration_trunc(TimeDelta::seconds(1)).unwrap())
         }
         // We truncate the initial date to the nearest second so that we're aligned to the second


### PR DESCRIPTION
This fixes a bug that occurs when multiple checkers are competing for the same progress key. If a checker saves the key, and then another boots and gets a value too close to the current time then we end up hitting an `OutOfRangeError` when we subtract `start` from `Utc::Now()`.