### PR TITLE
chore(uptime): Temporarily set bucket_size log to be `info`

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -115,7 +115,7 @@ async fn scheduler_loop(
                 .increment(1);
             }
         }
-        tracing::debug!(%tick, bucket_size = bucket_size, uptime_region = region, partition=partition.to_string(), "scheduler.tick_scheduled");
+        tracing::info!(%tick, bucket_size = bucket_size, uptime_region = region, partition=partition.to_string(), "scheduler.tick_scheduled");
         metrics::gauge!("scheduler.bucket_size", "uptime_region" => region.clone(), "partition" => partition.to_string())
         .set(bucket_size as f64);
 


### PR DESCRIPTION
I want to validate the `scheduler.bucket_size` metric, which seems like it's wrong.