### PR TITLE
fix(uptime): Fix slot distribution to use a `uuid5`

### DIFF
--- a/src/config_store.rs
+++ b/src/config_store.rs
@@ -149,7 +149,7 @@ mod tests {
 
     use crate::{
         config_store::{ConfigStore, Tick},
-        types::check_config::{CheckConfig, CheckInterval, MAX_CHECK_INTERVAL_SECS},
+        types::check_config::{CheckConfig, CheckInterval},
     };
 
     #[test]
@@ -171,7 +171,12 @@ mod tests {
     fn test_add_config() {
         let mut store = ConfigStore::new();
 
-        let config = Arc::new(CheckConfig::default());
+        let config = Arc::new(CheckConfig {
+            // 64 maps to 0 after converting to a uuid5 with our namespace
+            subscription_id: Uuid::from_u128(64),
+            ..Default::default()
+        });
+
         store.add_config(config.clone());
 
         assert_eq!(store.configs.len(), 1);
@@ -183,7 +188,7 @@ mod tests {
             // Cannot have multiple configs with the same subscription_id, to test configs that
             // exist in the same bucket manually create a uuid that slots into the 0th bucket after
             // wrapping around the max value.
-            subscription_id: Uuid::from_u128(MAX_CHECK_INTERVAL_SECS as u128),
+            subscription_id: Uuid::from_u128(9382),
             interval: CheckInterval::FiveMinutes,
             ..Default::default()
         });
@@ -207,6 +212,7 @@ mod tests {
 
         let config = Arc::new(CheckConfig {
             interval: CheckInterval::OneMinute,
+            subscription_id: Uuid::from_u128(174),
             ..Default::default()
         });
         store.add_config(config.clone());
@@ -218,6 +224,7 @@ mod tests {
 
         let config = Arc::new(CheckConfig {
             interval: CheckInterval::FiveMinutes,
+            subscription_id: Uuid::from_u128(174),
             ..Default::default()
         });
         store.add_config(config.clone());
@@ -246,7 +253,7 @@ mod tests {
         store.add_config(config.clone());
 
         let five_minute_config = Arc::new(CheckConfig {
-            subscription_id: Uuid::from_u128(MAX_CHECK_INTERVAL_SECS as u128),
+            subscription_id: Uuid::from_u128(9382),
             interval: CheckInterval::FiveMinutes,
             ..Default::default()
         });
@@ -268,11 +275,16 @@ mod tests {
     fn test_get_configs() {
         let mut store = ConfigStore::new();
 
-        let config = Arc::new(CheckConfig::default());
+        let config = Arc::new(CheckConfig {
+            // 64 maps to 0 after converting to a uuid5 with our namespace
+            subscription_id: Uuid::from_u128(64),
+            ..Default::default()
+        });
+
         store.add_config(config.clone());
 
         let five_minute_config = Arc::new(CheckConfig {
-            subscription_id: Uuid::from_u128(MAX_CHECK_INTERVAL_SECS as u128),
+            subscription_id: Uuid::from_u128(9382),
             interval: CheckInterval::FiveMinutes,
             ..Default::default()
         });

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -229,11 +229,11 @@ mod tests {
         let config_store = Arc::new(ConfigStore::new_rw());
 
         let config1 = Arc::new(CheckConfig {
-            subscription_id: Uuid::from_u128(1),
+            subscription_id: Uuid::from_u128(435),
             ..Default::default()
         });
         let config2 = Arc::new(CheckConfig {
-            subscription_id: Uuid::from_u128(3),
+            subscription_id: Uuid::from_u128(14),
             ..Default::default()
         });
 
@@ -338,14 +338,16 @@ mod tests {
         // so that it's in us_west.
         // For config 2, we need it to be `<val> % 60 == 3` and
         // `<val> % active_regions.length() == 1` so that it's in us_east.
+        // Note: These numbers are chosen so that the uuid5 we generate for them modulos to 1/3
+        // respectively, and places them in the same slot.
         let config1 = Arc::new(CheckConfig {
-            subscription_id: Uuid::from_u128(61),
+            subscription_id: Uuid::from_u128(2500),
             active_regions: Some(vec!["us_west".to_string(), "us_east".to_string()]),
             region_schedule_mode: Some(RegionScheduleMode::RoundRobin),
             ..Default::default()
         });
         let config2 = Arc::new(CheckConfig {
-            subscription_id: Uuid::from_u128(63),
+            subscription_id: Uuid::from_u128(1317),
             active_regions: Some(vec!["us_east".to_string(), "us_west".to_string()]),
             region_schedule_mode: Some(RegionScheduleMode::RoundRobin),
             ..Default::default()
@@ -449,11 +451,11 @@ mod tests {
         let config_store = Arc::new(ConfigStore::new_rw());
 
         let config1 = Arc::new(CheckConfig {
-            subscription_id: Uuid::from_u128(1),
+            subscription_id: Uuid::from_u128(435),
             ..Default::default()
         });
         let config2 = Arc::new(CheckConfig {
-            subscription_id: Uuid::from_u128(3),
+            subscription_id: Uuid::from_u128(14),
             ..Default::default()
         });
 

--- a/src/types/check_config.rs
+++ b/src/types/check_config.rs
@@ -24,8 +24,15 @@ pub enum CheckInterval {
 /// The largest check interval
 pub const MAX_CHECK_INTERVAL_SECS: usize = CheckInterval::SixtyMinutes as usize;
 
-/// A random hardcoded id that we use to generated v5 uuids based on subscription ids.
-pub const SUBSCRIPTION_ID_NAMESPACE: Uuid = Uuid::from_u128(31415926535897932384626433832795u128);
+/// A random hardcoded id that we use to generated v5 uuids based on subscription ids for assigning
+/// to slots.
+pub const SUBSCRIPTION_SLOT_NAMESPACE: Uuid =
+    Uuid::from_u128(134104732365955935133175004175948885464u128);
+
+/// A random hardcoded id that we use to generated v5 uuids based on subscription ids for deciding
+/// whether a subscription should run in this region.
+pub const SUBSCRIPTION_SHOULD_RUN_NAMESPACE: Uuid =
+    Uuid::from_u128(31415926535897932384626433832795u128);
 
 /// The CheckConfig represents a configuration for a single check.
 #[serde_as]
@@ -82,11 +89,19 @@ impl CheckConfig {
     pub fn slots(&self) -> Vec<usize> {
         let interval_secs = self.interval as usize;
 
-        let first_slot = self
-            .subscription_id
-            .as_u128()
-            .checked_rem(self.interval as u128)
-            .unwrap() as usize;
+        // We deterministically produce a new uuid here based on the subscription id and use it to
+        // help distribute subscriptions to slots. Without this, we end up distributing all checks
+        // associated with a specific partition into the same slots.
+        //
+        // We have to use this instead of the subscription id itself because we already use the
+        // subscription id to partition checks.
+        let first_slot = Uuid::new_v5(
+            &SUBSCRIPTION_SLOT_NAMESPACE,
+            self.subscription_id.as_bytes(),
+        )
+        .as_u128()
+        .checked_rem(self.interval as u128)
+        .unwrap() as usize;
 
         let pattern_count = MAX_CHECK_INTERVAL_SECS / interval_secs;
 
@@ -118,8 +133,10 @@ impl CheckConfig {
         // We have to use this instead of the subscription id itself because we already use the
         // subscription id distribute checks across the check interval. If we used it here, then
         // it'd mean that we still end up running checks for a given region at the same time.
-        let subscription_seed_id =
-            Uuid::new_v5(&SUBSCRIPTION_ID_NAMESPACE, self.subscription_id.as_bytes());
+        let subscription_seed_id = Uuid::new_v5(
+            &SUBSCRIPTION_SHOULD_RUN_NAMESPACE,
+            self.subscription_id.as_bytes(),
+        );
         let running_region_idx = (((tick.time().timestamp() / self.interval as i64) as u128)
             + subscription_seed_id.as_u128())
         .checked_rem(active_regions.len() as u128)
@@ -258,7 +275,11 @@ mod tests {
     fn test_slots() {
         let all_slots = 0..MAX_CHECK_INTERVAL_SECS;
 
-        let minute_config = CheckConfig::default();
+        let minute_config = CheckConfig {
+            // 64 maps to 0 after converting to a uuid5 with our namespace
+            subscription_id: Uuid::from_u128(64),
+            ..Default::default()
+        };
 
         // Every minute slot includes the config
         assert_eq!(
@@ -267,7 +288,8 @@ mod tests {
         );
 
         let hour_config = CheckConfig {
-            subscription_id: Uuid::from_u128(1),
+            // 15071 maps to 1 after converting to a uuid5 with our namespace
+            subscription_id: Uuid::from_u128(15071),
             interval: CheckInterval::SixtyMinutes,
             ..Default::default()
         };
@@ -277,6 +299,7 @@ mod tests {
 
         let five_minute_config = CheckConfig {
             interval: CheckInterval::FiveMinutes,
+            subscription_id: Uuid::from_u128(174),
             ..Default::default()
         };
 
@@ -287,7 +310,7 @@ mod tests {
         );
 
         let five_minute_config_offset = CheckConfig {
-            subscription_id: Uuid::from_u128(MAX_CHECK_INTERVAL_SECS as u128 + 15),
+            subscription_id: Uuid::from_u128(9737),
             interval: CheckInterval::FiveMinutes,
             ..Default::default()
         };


### PR DESCRIPTION
Our slot distribution is currently based on the subscription id. The problem with this is that `subscription_id` is already used to partition our configs. This has the side effect of causing configs in a partition to not be distributed evenly among scheduling slots. The result here is that partitions run all at once, then completely stop for a few ticks, then run again, and son on. Using a uuid with a different namespace here will distribute them more evenly.

Some math examples:
Since we modulo subscription ids by 128, then for example, anything that modulos to 51 goes in the same bucket.
For each of those ids in the 51 bucket, if we modulo those by 60 (the number of seconds for an interval), they all map to these numbers
[3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43, 47, 51, 55, 59]
if i do it for items in partition 50 instead
[2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42, 46, 50, 54, 58]

Since these all end up in only 1/4 of the total buckets, we end up with spikiness in our checks.