### PR TITLE
telemtry: log dns timing using fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.12.2"
-source = "git+https://github.com/getsentry/reqwest?branch=restricted-connector#7331a73eb2379c141d65d0cfed4ebcd36927a495"
+source = "git+https://github.com/getsentry/reqwest-uptime?branch=jferg/log-dns-timing#ba7a942d66d9b581b19d39086ec245cb053f239f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2904,6 +2904,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rand",
  "rustls-pemfile",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ ctor = "0.2"
 hostname = "0.4.0"
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }
-reqwest = { git = "https://github.com/getsentry/reqwest", branch = "restricted-connector" }
+reqwest = { git = "https://github.com/getsentry/reqwest-uptime", branch = "jferg/log-dns-timing" }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
first step of adding more timing telemetry -- let's log dns timing 1% of the time to see if this is impacting timeouts. branch here: https://github.com/getsentry/reqwest-uptime/pull/1