### PR TITLE
feat: hardcode reqwest fork revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.12.2"
-source = "git+https://github.com/getsentry/reqwest-uptime?branch=jferg/log-dns-timing#ba7a942d66d9b581b19d39086ec245cb053f239f"
+source = "git+https://github.com/getsentry/reqwest-uptime?rev=7408a3124f56130a1e89935841ae4314440ef309#7408a3124f56130a1e89935841ae4314440ef309"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ ctor = "0.2"
 hostname = "0.4.0"
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }
-reqwest = { git = "https://github.com/getsentry/reqwest-uptime", rev = "7408a3124f56130a1e89935841ae4314440ef309g" }
+reqwest = { git = "https://github.com/getsentry/reqwest-uptime", rev = "7408a3124f56130a1e89935841ae4314440ef309" }
 # we're using the jferg/log-dns-timing branch on the reqwest-uptime fork
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ ctor = "0.2"
 hostname = "0.4.0"
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }
-reqwest = { git = "https://github.com/getsentry/reqwest-uptime", branch = "jferg/log-dns-timing" }
+reqwest = { git = "https://github.com/getsentry/reqwest-uptime", rev = "7408a3124f56130a1e89935841ae4314440ef309g" }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ hostname = "0.4.0"
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }
 reqwest = { git = "https://github.com/getsentry/reqwest-uptime", rev = "7408a3124f56130a1e89935841ae4314440ef309g" }
+# we're using the jferg/log-dns-timing branch on the reqwest-uptime fork
 
 [profile.release]
 lto = true


### PR DESCRIPTION
hardcodes the revision. and updated the dns log to warn, as that is what our min log level is set in production. https://github.com/getsentry/reqwest-uptime/pull/1/commits/7408a3124f56130a1e89935841ae4314440ef309