### PR TITLE
bump dns cache size to 500k

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.12.2"
-source = "git+https://github.com/getsentry/reqwest-uptime?rev=df9d761891d3f1abdffe8d01221a047760b21fcc#df9d761891d3f1abdffe8d01221a047760b21fcc"
+source = "git+https://github.com/getsentry/reqwest-uptime?rev=012bc30a15cead582fc770a1a2ff76bc8c800ae5#012bc30a15cead582fc770a1a2ff76bc8c800ae5"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ ctor = "0.2"
 hostname = "0.4.0"
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }
-reqwest = { git = "https://github.com/getsentry/reqwest-uptime", rev = "df9d761891d3f1abdffe8d01221a047760b21fcc" }
+reqwest = { git = "https://github.com/getsentry/reqwest-uptime", rev = "012bc30a15cead582fc770a1a2ff76bc8c800ae5" }
 # we're using the jferg/log-dns-timing branch on the reqwest-uptime fork
 
 [profile.release]


### PR DESCRIPTION
https://github.com/getsentry/reqwest-uptime/pull/1/commits/012bc30a15cead582fc770a1a2ff76bc8c800ae5 100k looks good, not a huge increase in memory, can safely increase to 500k