### PR TITLE
test: Support queuing dummy results in DummyChecker

### DIFF
--- a/src/checker/dummy_checker.rs
+++ b/src/checker/dummy_checker.rs
@@ -2,6 +2,8 @@ use std::time::Duration;
 
 use chrono::Utc;
 use sentry::protocol::SpanId;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::sync::RwLock;
 use tokio::time;
 use uuid::Uuid;
 
@@ -10,16 +12,35 @@ use crate::config_store::Tick;
 use crate::types::check_config::CheckConfig;
 use crate::types::result::{CheckResult, CheckStatus};
 
+/// A DummyReuslt can be used to configure the DummyChecker with results to produce
 #[derive(Clone, Debug)]
+pub struct DummyResult {
+    pub delay: Option<Duration>,
+    pub status: CheckStatus,
+}
+
+impl Default for DummyResult {
+    fn default() -> Self {
+        Self {
+            delay: None,
+            status: CheckStatus::Success,
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct DummyChecker {
-    delay: Option<Duration>,
+    results: RwLock<UnboundedReceiver<DummyResult>>,
 }
 
 impl DummyChecker {
-    pub fn new(delay: impl Into<Option<Duration>>) -> Self {
-        Self {
-            delay: delay.into(),
-        }
+    pub fn new() -> (Self, UnboundedSender<DummyResult>) {
+        let (sender, reciever) = mpsc::unbounded_channel();
+        let checker = Self {
+            results: RwLock::new(reciever),
+        };
+
+        (checker, sender)
     }
 }
 
@@ -30,18 +51,20 @@ impl Checker for DummyChecker {
         let trace_id = Uuid::new_v4();
         let span_id = SpanId::default();
         let duration = None;
-        let status = CheckStatus::Success;
         let status_reason = None;
         let request_info = None;
 
-        if let Some(delay) = self.delay {
+        // Get queued results to yield
+        let result = self.results.write().await.recv().await.unwrap_or_default();
+
+        if let Some(delay) = result.delay {
             time::sleep(delay).await;
         }
 
         CheckResult {
             guid: Uuid::new_v4(),
             subscription_id: config.subscription_id,
-            status,
+            status: result.status,
             status_reason,
             trace_id,
             span_id,


### PR DESCRIPTION
This will allow us to have results with different status for each
sequential check.