### PR TITLE
feat(executor): Add optional retry for check executor

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -111,6 +111,9 @@ pub struct Config {
 
     /// Total number of uptime checkers running
     pub total_checkers: u16,
+
+    /// The number of times to retry failed checks before reporting them as failed
+    pub failure_retries: u16,
 }
 
 impl Default for Config {
@@ -141,6 +144,7 @@ impl Default for Config {
             disable_connection_reuse: true,
             checker_number: 0,
             total_checkers: 1,
+            failure_retries: 0,
         }
     }
 }
@@ -258,6 +262,7 @@ mod tests {
                         producer_mode: ProducerMode::Kafka,
                         vector_batch_size: 10,
                         vector_endpoint: "http://localhost:8020".to_owned(),
+                        failure_retries: 0,
                     }
                 );
             },
@@ -296,6 +301,7 @@ mod tests {
                 ("UPTIME_CHECKER_DISABLE_CONNECTION_REUSE", "false"),
                 ("UPTIME_CHECKER_CHECKER_NUMBER", "2"),
                 ("UPTIME_CHECKER_TOTAL_CHECKERS", "5"),
+                ("UPTIME_CHECKER_FAILURE_RETRIES", "2"),
             ],
             |config| {
                 assert_eq!(
@@ -329,6 +335,7 @@ mod tests {
                         producer_mode: ProducerMode::Kafka,
                         vector_batch_size: 10,
                         vector_endpoint: "http://localhost:8020".to_owned(),
+                        failure_retries: 2,
                     }
                 );
             },

--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -20,6 +20,8 @@ pub struct ScheduledCheck {
     tick: Tick,
     config: Arc<CheckConfig>,
     resolve_tx: Sender<CheckResult>,
+    /// The number of times this scheduled check has been retried
+    retry_count: u16,
 }
 
 impl ScheduledCheck {
@@ -71,6 +73,7 @@ impl CheckSender {
             tick,
             config,
             resolve_tx,
+            retry_count: 0,
         };
 
         self.queue_size.fetch_add(1, Ordering::SeqCst);
@@ -79,6 +82,15 @@ impl CheckSender {
             .expect("Failed to queue ScheduledCheck");
 
         resolve_rx
+    }
+
+    /// Requeues the check to be executed again, increasing the number of retries by 1
+    fn queue_check_for_retry(&self, mut check: ScheduledCheck) {
+        check.retry_count += 1;
+        self.queue_size.fetch_add(1, Ordering::SeqCst);
+        self.sender
+            .send(check)
+            .expect("Failed to queue ScheduledCheck");
     }
 }
 
@@ -103,55 +115,78 @@ impl CheckResult {
 
 pub fn run_executor(
     concurrency: usize,
+    failure_retries: u16,
     checker: Arc<impl Checker + 'static>,
     producer: Arc<impl ResultsProducer + 'static>,
     region: String,
-) -> (CheckSender, JoinHandle<()>) {
+) -> (Arc<CheckSender>, JoinHandle<()>) {
     tracing::info!("executor.starting");
 
-    let (check_sender, receiver) = CheckSender::new();
-    let queue_size = check_sender.queue_size.clone();
-    let num_running = check_sender.num_running.clone();
+    let (sender, reciever) = CheckSender::new();
+    let queue_size = sender.queue_size.clone();
+    let num_running = sender.num_running.clone();
 
-    let executor = tokio::spawn(async move {
+    let check_sender = Arc::new(sender);
+    let executor_check_sender = check_sender.clone();
+
+    let conf = ExecutorConfig {
+        concurrency,
+        failure_retries,
+        region,
+    };
+
+    let executor_handle = tokio::spawn(async move {
         executor_loop(
-            concurrency,
+            conf,
             queue_size,
             num_running,
             checker,
             producer,
-            receiver,
-            region,
+            executor_check_sender,
+            reciever,
         )
         .await
     });
 
-    (check_sender, executor)
+    (check_sender, executor_handle)
+}
+
+struct ExecutorConfig {
+    /// Number of checks that will be executed at the same time.
+    concurrency: usize,
+
+    /// Number of times a check will be retred when the execution of the check results in a
+    /// failure.
+    failure_retries: u16,
+
+    /// The region the checker checker is running as
+    region: String,
 }
 
 async fn executor_loop(
-    concurrency: usize,
+    conf: ExecutorConfig,
     queue_size: Arc<AtomicU64>,
     num_running: Arc<AtomicU64>,
     checker: Arc<impl Checker + 'static>,
     producer: Arc<impl ResultsProducer + 'static>,
-    reciever: UnboundedReceiver<ScheduledCheck>,
-    region: String,
+    check_sender: Arc<CheckSender>,
+    check_receiver: UnboundedReceiver<ScheduledCheck>,
 ) {
-    let schedule_check_stream: UnboundedReceiverStream<_> = reciever.into();
+    let schedule_check_stream: UnboundedReceiverStream<_> = check_receiver.into();
 
     schedule_check_stream
-        .for_each_concurrent(concurrency, |scheduled_check| {
+        .for_each_concurrent(conf.concurrency, |scheduled_check| {
             let job_checker = checker.clone();
             let job_producer = producer.clone();
-            let job_region = region.clone();
+            let job_region = conf.region.clone();
             let job_num_running = num_running.clone();
+            let job_check_sender = check_sender.clone();
 
             num_running.fetch_add(1, Ordering::SeqCst);
             queue_size.fetch_sub(1, Ordering::SeqCst);
-            metrics::gauge!("executor.queue_size", "uptime_region" => region.clone())
+            metrics::gauge!("executor.queue_size", "uptime_region" => conf.region.clone())
                 .set(queue_size.load(Ordering::SeqCst) as f64);
-            metrics::gauge!("executor.num_running", "uptime_region" => region.clone())
+            metrics::gauge!("executor.num_running", "uptime_region" => conf.region.clone())
                 .set(num_running.load(Ordering::SeqCst) as f64);
 
             async move {
@@ -170,11 +205,27 @@ async fn executor_loop(
                         job_checker.check_url(config, tick, &job_region).await
                     };
 
+                    let will_retry = check_result.status == CheckStatus::Failure
+                        && scheduled_check.retry_count < conf.failure_retries;
+
+                    record_result_metrics(
+                        &check_result,
+                        scheduled_check.retry_count > 0,
+                        will_retry,
+                    );
+
+                    // re-queue for execution again
+                    if will_retry {
+                        tracing::debug!(result = ?check_result, "executor.check_will_retry");
+                        job_check_sender.queue_check_for_retry(scheduled_check);
+                        job_num_running.fetch_sub(1, Ordering::SeqCst);
+                        return;
+                    }
+
                     if let Err(e) = job_producer.produce_checker_result(&check_result) {
                         tracing::error!(error = ?e, "executor.failed_to_produce");
                     }
 
-                    record_result_metrics(&check_result);
                     tracing::debug!(result = ?check_result, "executor.check_complete");
 
                     scheduled_check.record_result(check_result);
@@ -187,7 +238,7 @@ async fn executor_loop(
     tracing::info!("executor.shutdown");
 }
 
-fn record_result_metrics(result: &CheckResult) {
+fn record_result_metrics(result: &CheckResult, is_retry: bool, will_retry: bool) {
     // Record metrics
     let CheckResult {
         status,
@@ -217,6 +268,9 @@ fn record_result_metrics(result: &CheckResult) {
         Some(status) => status.to_string(),
     };
 
+    let retry_label = if is_retry { "true" } else { "false" };
+    let will_retry_label = if will_retry { "true" } else { "false" };
+
     // Record duration of check
     if let Some(duration) = duration {
         metrics::histogram!(
@@ -226,6 +280,8 @@ fn record_result_metrics(result: &CheckResult) {
             "failure_reason" => failure_reason.unwrap_or("ok"),
             "status_code" => status_code.clone(),
             "uptime_region" => result.region.clone(),
+            "is_retry" => retry_label,
+            "will_retry" => will_retry_label,
         )
         .record(duration.to_std().unwrap().as_secs_f64());
     }
@@ -243,6 +299,8 @@ fn record_result_metrics(result: &CheckResult) {
         "failure_reason" => failure_reason.unwrap_or("ok"),
         "status_code" => status_code.clone(),
         "uptime_region" => result.region.clone(),
+        "is_retry" => retry_label,
+        "will_retry" => will_retry_label,
     )
     .record(delay);
 
@@ -253,6 +311,8 @@ fn record_result_metrics(result: &CheckResult) {
         "failure_reason" => failure_reason.unwrap_or("ok"),
         "status_code" => status_code,
         "uptime_region" => result.region.clone(),
+        "is_retry" => retry_label,
+        "will_retry" => will_retry_label,
     )
     .increment(1);
 }
@@ -287,7 +347,7 @@ mod tests {
         let checker = Arc::new(dummy_checker);
         let producer = Arc::new(DummyResultsProducer::new("uptime-results"));
 
-        let (sender, _) = run_executor(1, checker, producer, "us-west".to_string());
+        let (sender, _) = run_executor(1, 0, checker, producer, "us-west".to_string());
 
         let tick = Tick::from_time(Utc::now());
         let config = Arc::new(CheckConfig {
@@ -324,7 +384,7 @@ mod tests {
         let producer = Arc::new(DummyResultsProducer::new("uptime-results"));
 
         // Only allow 2 configs to execute concurrently
-        let (sender, _) = run_executor(2, checker, producer, "us-west".to_string());
+        let (sender, _) = run_executor(2, 0, checker, producer, "us-west".to_string());
 
         // Send 4 configs into the executor
         let mut configs: Vec<Receiver<CheckResult>> = (0..4)
@@ -402,7 +462,7 @@ mod tests {
         let checker = Arc::new(dummy_checker);
         let producer = Arc::new(DummyResultsProducer::new("uptime-results"));
 
-        let (sender, _) = run_executor(1, checker, producer, "us-west".to_string());
+        let (sender, _) = run_executor(1, 0, checker, producer, "us-west".to_string());
 
         let tick = Tick::from_time(Utc::now() - TimeDelta::minutes(2));
         let config = Arc::new(CheckConfig {
@@ -415,5 +475,82 @@ mod tests {
 
         assert_eq!(result.subscription_id, config.subscription_id);
         assert_eq!(result.status, CheckStatus::MissedWindow);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_executor_retry() {
+        let failed_result = DummyResult {
+            delay: Some(Duration::from_secs(1)),
+            status: CheckStatus::Failure,
+        };
+        let success_result = DummyResult {
+            delay: Some(Duration::from_secs(1)),
+            status: CheckStatus::Success,
+        };
+
+        // One failure then one success
+        let (dummy_checker, dummy_result_queue) = DummyChecker::new();
+        dummy_result_queue.send(failed_result).unwrap();
+        dummy_result_queue.send(success_result).unwrap();
+
+        let checker = Arc::new(dummy_checker);
+        let producer = Arc::new(DummyResultsProducer::new("uptime-results"));
+
+        // Allow one retry
+        let (sender, _) = run_executor(1, 1, checker, producer, "us-west".to_string());
+
+        let tick = Tick::from_time(Utc::now());
+        let config = Arc::new(CheckConfig {
+            subscription_id: Uuid::from_u128(1),
+            ..Default::default()
+        });
+
+        let resolve_rx = sender.queue_check(tick, config.clone());
+        tokio::pin!(resolve_rx);
+
+        // Resolves as success since we will retry
+        let result = resolve_rx.await.unwrap();
+        assert_eq!(result.subscription_id, config.subscription_id);
+        assert_eq!(result.status, CheckStatus::Success);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_executor_retry_failed() {
+        let failed_result = DummyResult {
+            delay: Some(Duration::from_secs(1)),
+            status: CheckStatus::Failure,
+        };
+        let success_result = DummyResult {
+            delay: Some(Duration::from_secs(1)),
+            status: CheckStatus::Success,
+        };
+
+        // Three failure then one success, we won't get the success since our retry limit is 2, so
+        // we'll fail once, retry twice, and report the last failure
+        let (dummy_checker, dummy_result_queue) = DummyChecker::new();
+        dummy_result_queue.send(failed_result.clone()).unwrap();
+        dummy_result_queue.send(failed_result.clone()).unwrap();
+        dummy_result_queue.send(failed_result.clone()).unwrap();
+        dummy_result_queue.send(success_result).unwrap();
+
+        let checker = Arc::new(dummy_checker);
+        let producer = Arc::new(DummyResultsProducer::new("uptime-results"));
+
+        // Allow two retries
+        let (sender, _) = run_executor(1, 2, checker, producer, "us-west".to_string());
+
+        let tick = Tick::from_time(Utc::now());
+        let config = Arc::new(CheckConfig {
+            subscription_id: Uuid::from_u128(1),
+            ..Default::default()
+        });
+
+        let resolve_rx = sender.queue_check(tick, config.clone());
+        tokio::pin!(resolve_rx);
+
+        // Resolves as failure after the two retries
+        let result = resolve_rx.await.unwrap();
+        assert_eq!(result.subscription_id, config.subscription_id);
+        assert_eq!(result.status, CheckStatus::Failure);
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -19,7 +19,7 @@ use redis::AsyncCommands;
 pub fn run_scheduler(
     partition: u16,
     config_store: Arc<RwConfigStore>,
-    executor_sender: CheckSender,
+    executor_sender: Arc<CheckSender>,
     shutdown: CancellationToken,
     progress_key: String,
     redis_host: String,
@@ -48,7 +48,7 @@ pub fn run_scheduler(
 async fn scheduler_loop(
     partition: u16,
     config_store: Arc<RwConfigStore>,
-    executor_sender: CheckSender,
+    executor_sender: Arc<CheckSender>,
     shutdown: CancellationToken,
     progress_key: String,
     redis_host: String,
@@ -250,7 +250,7 @@ mod tests {
         let join_handle = run_scheduler(
             partition,
             config_store,
-            executor_tx,
+            Arc::new(executor_tx),
             shutdown_token.clone(),
             build_progress_key(0),
             config.redis_host.clone(),
@@ -366,7 +366,7 @@ mod tests {
         let join_handle = run_scheduler(
             partition,
             config_store,
-            executor_tx,
+            Arc::new(executor_tx),
             shutdown_token.clone(),
             build_progress_key(0),
             config.redis_host.clone(),
@@ -472,7 +472,7 @@ mod tests {
         let join_handle = run_scheduler(
             partition,
             config_store,
-            executor_tx,
+            Arc::new(executor_tx),
             shutdown_token.clone(),
             progress_key.clone(),
             config.redis_host.clone(),
@@ -576,7 +576,7 @@ mod tests {
         let join_handle = run_scheduler(
             partition,
             config_store,
-            executor_tx,
+            Arc::new(executor_tx),
             shutdown_token.clone(),
             progress_key.clone(),
             config.redis_host.clone(),


### PR DESCRIPTION
This adds a new option to allow for retrying failed checks by re-queuing
the check into the executor.

We will continue to record result metrics, but will include a tag
indicating if the result was a retry or not.