### PR TITLE
feat(uptime): add redirect errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -1993,7 +1993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3323,9 +3323,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-kafka-schemas"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775426b2478f7dd0002f533db77aaaea575966057d39a8b3f1cf58e68d7f2b8b"
+checksum = "e947a81fe9a146f9f7a8a2544afe0f950b03022f6a99426f527c728f527fffea"
 dependencies = [
  "jsonschema",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json"] }
 tracing-test = "0.2.5"
 console = "0.15.8"
-sentry-kafka-schemas = "1.0.5"
+sentry-kafka-schemas = "1.1.0"
 serde_with = { version = "3.8.1", features = ["chrono"] }
 rmp-serde = "1.3.0"
 serde_repr = "0.1.19"

--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -261,6 +261,7 @@ fn record_result_metrics(result: &CheckResult, is_retry: bool, will_retry: bool)
         Some(CheckStatusReasonType::Timeout) => Some("timeout"),
         Some(CheckStatusReasonType::TlsError) => Some("tls_error"),
         Some(CheckStatusReasonType::ConnectionError) => Some("connection_error"),
+        Some(CheckStatusReasonType::RedirectError) => Some("redirect_error"),
         None => None,
     };
     let status_code = match request_info.as_ref().and_then(|a| a.http_status_code) {

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -235,6 +235,11 @@ impl Checker for HttpChecker {
                         status_type: CheckStatusReasonType::Timeout,
                         description: "Request timed out".to_string(),
                     }
+                } else if e.is_redirect() {
+                    CheckStatusReason {
+                        status_type: CheckStatusReasonType::RedirectError,
+                        description: "Too many redirects".to_string(),
+                    }
                 } else if let Some(message) = dns_error(&e) {
                     CheckStatusReason {
                         status_type: CheckStatusReasonType::DnsError,

--- a/src/types/result.rs
+++ b/src/types/result.rs
@@ -31,6 +31,7 @@ pub enum CheckStatusReasonType {
     DnsError,
     TlsError,
     ConnectionError,
+    RedirectError,
     Failure,
 }
 


### PR DESCRIPTION
note that we can't deploy this untill a corresponding `redirect_error` has been added to the sentry kafka repo and then the uptime checker, sentry, and snuba have all been bumped with the new version of the library