### PR TITLE
feat: catch hyper util errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,6 +4270,7 @@ dependencies = [
  "hostname 0.4.0",
  "httpmock",
  "hyper 1.4.1",
+ "hyper-util",
  "ipnet",
  "metrics",
  "metrics-exporter-statsd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.80"
 
 [dependencies]
 hyper = "1.4.1"
+hyper-util = "0.1.10"
 anyhow = "1.0.66"
 clap = { version = "4.4.6", features = ["derive"] }
 chrono = { version = "0.4.31", default-features = false, features = ["std", "serde"] }

--- a/Dockerfile.localdev
+++ b/Dockerfile.localdev
@@ -21,7 +21,7 @@ RUN mkdir -p ~/.cargo && \
     echo 'protocol = "sparse"' >> ~/.cargo/config
 
 RUN apk add --no-cache libc-dev cmake make g++
-RUN apk add --no-cache pkgconfig openssl-dev
+RUN apk add --no-cache pkgconfig openssl-dev protoc
 
 RUN cargo new --bin /app
 WORKDIR /app

--- a/Dockerfile.localdev
+++ b/Dockerfile.localdev
@@ -6,7 +6,7 @@
 
 # HOW TO USE:
 # 1. Build the binary: `docker build -f Dockerfile.localdev -t my-uptime-checker`
-# 2. Run the container with a mounted volume for src: `docker run -it -v $(pwd)/src:/app/src --entrypoint /bin/sh my-uptime-checker`
+# 2. Run the container with a mounted volume for src: ```
 # e. in the container you can do `cargo test`, etc. and updating the src directory on your host will reflect in the container,
 # so you can test your changes without having to rebuild the container.
 ##
@@ -21,7 +21,7 @@ RUN mkdir -p ~/.cargo && \
     echo 'protocol = "sparse"' >> ~/.cargo/config
 
 RUN apk add --no-cache libc-dev cmake make g++
-RUN apk add --no-cache pkgconfig openssl-dev protoc
+RUN apk add --no-cache pkgconfig openssl-dev protoc`
 
 RUN cargo new --bin /app
 WORKDIR /app

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -143,6 +143,22 @@ fn hyper_error(err: &reqwest::Error) -> Option<(CheckStatusReasonType, String)> 
     }
     None
 }
+fn hyper_util_error(err: &reqwest::Error) -> Option<(CheckStatusReasonType, String)> {
+    let mut inner = &err as &dyn Error;
+    while let Some(source) = inner.source() {
+        if let Some(hyper_util_error) = source.downcast_ref::<hyper_util::client::legacy::Error>() {
+            if hyper_util_error.is_connect() {
+                return Some((
+                    CheckStatusReasonType::ConnectionError,
+                    hyper_util_error.to_string(),
+                ));
+            }
+            return Some((CheckStatusReasonType::Failure, hyper_util_error.to_string()));
+        }
+        inner = source;
+    }
+    None
+}
 
 impl HttpChecker {
     fn new_internal(options: Options) -> Self {
@@ -251,6 +267,11 @@ impl Checker for HttpChecker {
                         description: message,
                     }
                 } else if let Some((status_type, message)) = hyper_error(&e) {
+                    CheckStatusReason {
+                        status_type,
+                        description: message,
+                    }
+                } else if let Some((status_type, message)) = hyper_util_error(&e) {
                     CheckStatusReason {
                         status_type,
                         description: message,

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -150,7 +150,6 @@ fn hyper_util_error(err: &reqwest::Error) -> Option<(CheckStatusReasonType, Stri
     let mut inner = &err as &dyn Error;
     while let Some(source) = inner.source() {
         if let Some(hyper_util_error) = source.downcast_ref::<hyper_util::client::legacy::Error>() {
-            println!("hyper_util_error: {:?}", hyper_util_error);
             if hyper_util_error.is_connect() {
                 return Some((
                     CheckStatusReasonType::ConnectionError,
@@ -873,101 +872,4 @@ mod tests {
             result_description
         );
     }
-
-    #[tokio::test]
-    #[cfg(target_os = "linux")]
-    async fn test_host_unreachable_linux() {
-        let checker = HttpChecker::new_internal(Options {
-            validate_url: false,
-            disable_connection_reuse: true,
-        });
-        let tick = make_tick();
-        
-        // On Linux, connecting to 192.0.2.0/24 (TEST-NET-1) with a specific setup
-        // should generate EHOSTUNREACH (error code 113)
-        let config = CheckConfig {
-            url: "http://192.0.2.1:8080/".to_string(),
-            timeout: TimeDelta::seconds(1),
-            ..Default::default()
-        };
-        
-        let result = checker.check_url(&config, &tick, "us-west").await;
-
-        assert_eq!(result.status, CheckStatus::Failure);
-        assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
-        assert_eq!(
-            result.status_reason.as_ref().map(|r| r.status_type),
-            Some(CheckStatusReasonType::ConnectionError)
-        );
-        
-        let result_description = result.status_reason.map(|r| r.description).unwrap();
-        println!("Error description: {}", result_description);
-        
-        // On Linux with the right network setup, this should contain "host unreachable"
-        // but we'll make the assertion flexible to accommodate different environments
-        assert!(
-            result_description.contains("connect error") || 
-            result_description.contains("unreachable"),
-            "Expected error message about host being unreachable: {}",
-            result_description
-        );
-    }
-
-    // #[tokio::test]
-    // #[cfg(not(target_os = "linux"))]
-    // async fn test_host_unreachable() {
-    //     // For non-Linux platforms, we'll use a different approach
-    //     // We'll use a socket that's bound to a non-routable address
-    //     // This should produce a connection error similar to "Host Unreachable"
-        
-    //     let checker = HttpChecker::new_internal(Options {
-    //         validate_url: false,
-    //         disable_connection_reuse: true,
-    //     });
-    //     let tick = make_tick();
-        
-    //     // Use a network that should be unreachable from the local machine
-    //     // 198.51.100.0/24 is TEST-NET-2, reserved for documentation and testing
-    //     // This should cause a connection error rather than a timeout
-    //     let config = CheckConfig {
-    //         // Use a very specific IP and port that should be unreachable
-    //         url: "http://198.51.100.250:34567/".to_string(),
-    //         // Short timeout to make the test run faster
-    //         timeout: TimeDelta::milliseconds(500),
-    //         ..Default::default()
-    //     };
-        
-    //     let result = checker.check_url(&config, &tick, "us-west").await;
-        
-    //     assert_eq!(result.status, CheckStatus::Failure);
-    //     assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
-        
-    //     // The error should be classified as a connection error or timeout
-    //     let status_type = result.status_reason.as_ref().map(|r| r.status_type);
-        
-    //     // Print the error description and type for debugging
-    //     let result_description = result.status_reason.as_ref().map(|r| r.description.clone()).unwrap();
-    //     println!("Error type: {:?}, description: {}", status_type, result_description);
-        
-    //     // On macOS, this might be classified as a timeout or connection error
-    //     // We'll accept either for the test to pass
-    //     assert!(
-    //         status_type == Some(CheckStatusReasonType::ConnectionError)
-    //     );
-        
-    //     // The error message should indicate a connection problem
-    //     // We're specifically looking for errors that would be similar to "Host Unreachable"
-    //     assert!(
-    //         result_description.contains("connect error") || 
-    //         result_description.contains("connection failed") || 
-    //         result_description.contains("timed out") ||
-    //         result_description.contains("unreachable"),
-    //         "Expected error message about connection failure: {}",
-    //         result_description
-    //     );
-        
-    //     // This test simulates the error:
-    //     // reqwest::Error { kind: Request, source: hyper_util::client::legacy::Error(Connect, ConnectError("tcp connect error", Os { code: 113, kind: HostUnreachable, message: "Host is unreachable" })
-    //     // On non-Linux platforms, we might not get the exact same error, but we should get something similar
-    // }
 }


### PR DESCRIPTION
looking at this https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0A-jsonPayload.message%3D%22scheduler.tick_scheduled%22%0Alabels.%22k8s-pod%2Fservice%22%3D%22uptime-checker%22%0A-%22DNS%22;summaryFields=:true:32:beginning;cursorTimestamp=2025-02-24T22:52:57.665242903Z;duration=PT15S?project=internal-sentry

we can see there are a lot of raw errors making it through. some of them are these hyper_util errors. we need to pin the library from being a sub-dependency so we can use the error here to cast it and return the parsed error.

it looks like there are some ssl errors which can make it into this category, so can follow up to try to separate those. specifically 
```
check_url.error: reqwest::Error { kind: Request, source: hyper_util::client::legacy::Error(Connect, Ssl(Error { code: ErrorCode(5), cause: None }, X509VerifyResult { code: 0, error: "ok" })) }
```