### PR TITLE
feat(uptime): Add setting to control how long we keep sockets to servers alive

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -105,6 +105,9 @@ pub struct Config {
     /// Whether to disable connection re-use in the http checker
     pub disable_connection_reuse: bool,
 
+    /// Sets the maximum time in seconds to keep idle sockets alive in the http checker.
+    pub pool_idle_timeout_secs: u64,
+
     /// The unioque index of this checker out of the total nuimber of checkers. Should be
     /// zero-indexed.
     pub checker_number: u16,
@@ -142,6 +145,7 @@ impl Default for Config {
             region: "default".to_owned(),
             allow_internal_ips: false,
             disable_connection_reuse: true,
+            pool_idle_timeout_secs: 90,
             checker_number: 0,
             total_checkers: 1,
             failure_retries: 0,
@@ -257,6 +261,7 @@ mod tests {
                         region: "default".to_owned(),
                         allow_internal_ips: false,
                         disable_connection_reuse: true,
+                        pool_idle_timeout_secs: 90,
                         checker_number: 0,
                         total_checkers: 1,
                         producer_mode: ProducerMode::Kafka,
@@ -299,6 +304,7 @@ mod tests {
                 ("UPTIME_CHECKER_REGION", "us-west"),
                 ("UPTIME_CHECKER_ALLOW_INTERNAL_IPS", "true"),
                 ("UPTIME_CHECKER_DISABLE_CONNECTION_REUSE", "false"),
+                ("UPTIME_CHECKER_POOL_IDLE_TIMEOUT_SECS", "600"),
                 ("UPTIME_CHECKER_CHECKER_NUMBER", "2"),
                 ("UPTIME_CHECKER_TOTAL_CHECKERS", "5"),
                 ("UPTIME_CHECKER_FAILURE_RETRIES", "2"),
@@ -330,6 +336,7 @@ mod tests {
                         region: "us-west".to_owned(),
                         allow_internal_ips: true,
                         disable_connection_reuse: false,
+                        pool_idle_timeout_secs: 600,
                         checker_number: 2,
                         total_checkers: 5,
                         producer_mode: ProducerMode::Kafka,

--- a/src/checker/http_checker.rs
+++ b/src/checker/http_checker.rs
@@ -172,7 +172,11 @@ impl HttpChecker {
         Self { client }
     }
 
-    pub fn new(validate_url: bool, disable_connection_reuse: bool, pool_idle_timeout: Duration) -> Self {
+    pub fn new(
+        validate_url: bool,
+        disable_connection_reuse: bool,
+        pool_idle_timeout: Duration,
+    ) -> Self {
         Self::new_internal(Options {
             validate_url,
             disable_connection_reuse,
@@ -291,13 +295,13 @@ impl Checker for HttpChecker {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
     use crate::checker::http_checker::make_trace_header;
     use crate::checker::Checker;
     use crate::config_store::Tick;
     use crate::types::check_config::CheckConfig;
     use crate::types::result::{CheckStatus, CheckStatusReasonType};
     use crate::types::shared::RequestMethod;
+    use std::time::Duration;
 
     use super::{HttpChecker, Options, UPTIME_USER_AGENT};
     use chrono::{TimeDelta, Utc};

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -2,11 +2,11 @@ use futures::{Future, StreamExt};
 use rust_arroyo::backends::kafka::config::KafkaConfig;
 use std::collections::hash_map::Entry::Vacant;
 use std::pin::Pin;
+use std::time::Duration;
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, RwLock},
 };
-use std::time::Duration;
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::UnboundedReceiverStream;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -6,6 +6,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, RwLock},
 };
+use std::time::Duration;
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -111,6 +112,7 @@ impl Manager {
         let checker = Arc::new(HttpChecker::new(
             !config.allow_internal_ips,
             config.disable_connection_reuse,
+            Duration::from_secs(config.pool_idle_timeout_secs),
         ));
 
         let (executor_sender, (executor_join_handle, results_worker)) = match &config.producer_mode


### PR DESCRIPTION
We disabled connection pooling before because it was causing random failures. Now that we have automated retries, it makes sense to re-enable this. We'd like to also increase the keepalive time so that we can re-use connections for longer.