### PR TITLE
feat(metrics): Monitor executor task metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,7 +1536,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -1982,9 +1982,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libloading"
@@ -1993,7 +1993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3885,9 +3885,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3904,13 +3904,25 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb2bb07a8451c4c6fa8b3497ad198510d8b8dffa5df5cfb97a64102a58b113c8"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -4291,6 +4303,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tokio-metrics",
  "tokio-rustls",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ rcgen = "0.11"
 time = "0.3"
 ctor = "0.2"
 hostname = "0.4.0"
+tokio-metrics = "0.4.0"
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }
 reqwest = { git = "https://github.com/getsentry/reqwest-uptime", rev = "012bc30a15cead582fc770a1a2ff76bc8c800ae5" }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -105,6 +105,10 @@ pub struct Config {
     /// Whether to disable connection re-use in the http checker
     pub disable_connection_reuse: bool,
 
+    /// Whether to record metrics for check executor tasks. May be used to diagnose scheduling
+    /// problems with the http check executors.
+    pub record_task_metrics: bool,
+
     /// Sets the maximum time in seconds to keep idle sockets alive in the http checker.
     pub pool_idle_timeout_secs: u64,
 
@@ -146,6 +150,7 @@ impl Default for Config {
             allow_internal_ips: false,
             disable_connection_reuse: true,
             pool_idle_timeout_secs: 90,
+            record_task_metrics: false,
             checker_number: 0,
             total_checkers: 1,
             failure_retries: 0,
@@ -261,6 +266,7 @@ mod tests {
                         region: "default".to_owned(),
                         allow_internal_ips: false,
                         disable_connection_reuse: true,
+                        record_task_metrics: false,
                         pool_idle_timeout_secs: 90,
                         checker_number: 0,
                         total_checkers: 1,
@@ -336,6 +342,7 @@ mod tests {
                         region: "us-west".to_owned(),
                         allow_internal_ips: true,
                         disable_connection_reuse: false,
+                        record_task_metrics: false,
                         pool_idle_timeout_secs: 600,
                         checker_number: 2,
                         total_checkers: 5,

--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use chrono::{TimeDelta, Utc};
 use futures::StreamExt;
@@ -113,12 +114,25 @@ impl CheckResult {
     }
 }
 
+pub struct ExecutorConfig {
+    /// Number of checks that will be executed at the same time.
+    pub concurrency: usize,
+
+    /// Number of times a check will be retred when the execution of the check results in a
+    /// failure.
+    pub failure_retries: u16,
+
+    /// The region the checker checker is running as
+    pub region: String,
+
+    /// Track metrics about executed tasks
+    pub record_task_metrics: bool,
+}
+
 pub fn run_executor(
-    concurrency: usize,
-    failure_retries: u16,
     checker: Arc<impl Checker + 'static>,
     producer: Arc<impl ResultsProducer + 'static>,
-    region: String,
+    conf: ExecutorConfig,
 ) -> (Arc<CheckSender>, JoinHandle<()>) {
     tracing::info!("executor.starting");
 
@@ -128,12 +142,6 @@ pub fn run_executor(
 
     let check_sender = Arc::new(sender);
     let executor_check_sender = check_sender.clone();
-
-    let conf = ExecutorConfig {
-        concurrency,
-        failure_retries,
-        region,
-    };
 
     let executor_handle = tokio::spawn(async move {
         executor_loop(
@@ -151,18 +159,6 @@ pub fn run_executor(
     (check_sender, executor_handle)
 }
 
-struct ExecutorConfig {
-    /// Number of checks that will be executed at the same time.
-    concurrency: usize,
-
-    /// Number of times a check will be retred when the execution of the check results in a
-    /// failure.
-    failure_retries: u16,
-
-    /// The region the checker checker is running as
-    region: String,
-}
-
 async fn executor_loop(
     conf: ExecutorConfig,
     queue_size: Arc<AtomicU64>,
@@ -174,6 +170,21 @@ async fn executor_loop(
 ) {
     let schedule_check_stream: UnboundedReceiverStream<_> = check_receiver.into();
 
+    // construct a metrics taskmonitor
+    let metrics_monitor = tokio_metrics::TaskMonitor::new();
+
+    // record metrics to datadog every 10 seconds
+    if conf.record_task_metrics {
+        let metrics_region = conf.region.clone();
+        let metrics_monitor = metrics_monitor.clone();
+        tokio::spawn(async move {
+            for interval in metrics_monitor.intervals() {
+                record_task_metrics(interval, metrics_region.clone());
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            }
+        });
+    }
+
     schedule_check_stream
         .for_each_concurrent(conf.concurrency, |scheduled_check| {
             let job_checker = checker.clone();
@@ -181,6 +192,8 @@ async fn executor_loop(
             let job_region = conf.region.clone();
             let job_num_running = num_running.clone();
             let job_check_sender = check_sender.clone();
+
+            let job_metrics_monitor = metrics_monitor.clone();
 
             num_running.fetch_add(1, Ordering::SeqCst);
             queue_size.fetch_sub(1, Ordering::SeqCst);
@@ -190,7 +203,7 @@ async fn executor_loop(
                 .set(num_running.load(Ordering::SeqCst) as f64);
 
             async move {
-                let _ = tokio::spawn(async move {
+                let check_task = async move {
                     let config = &scheduled_check.config;
                     let tick = &scheduled_check.tick;
 
@@ -230,8 +243,13 @@ async fn executor_loop(
 
                     scheduled_check.record_result(check_result);
                     job_num_running.fetch_sub(1, Ordering::SeqCst);
-                })
-                .await;
+                };
+
+                if conf.record_task_metrics {
+                    let _ = job_metrics_monitor.instrument(check_task).await;
+                } else {
+                    let _ = tokio::spawn(check_task).await;
+                }
             }
         })
         .await;
@@ -317,6 +335,49 @@ fn record_result_metrics(result: &CheckResult, is_retry: bool, will_retry: bool)
     .increment(1);
 }
 
+fn record_task_metrics(interval: tokio_metrics::TaskMetrics, region: String) {
+    metrics::gauge!(
+        "executor_task.mean_first_poll_delay",
+        "uptime_region" => region.clone(),
+    )
+    .set(interval.mean_first_poll_delay());
+    metrics::gauge!(
+        "executor_task.mean_idle_duration",
+        "uptime_region" => region.clone(),
+    )
+    .set(interval.mean_idle_duration());
+    metrics::gauge!(
+        "executor_task.mean_poll_duration",
+        "uptime_region" => region.clone(),
+    )
+    .set(interval.mean_poll_duration());
+    metrics::gauge!(
+        "executor_task.mean_scheduled_duration",
+        "uptime_region" => region.clone(),
+    )
+    .set(interval.mean_scheduled_duration());
+    metrics::gauge!(
+        "executor_task.mean_fast_poll_duration",
+        "uptime_region" => region.clone(),
+    )
+    .set(interval.mean_fast_poll_duration());
+    metrics::gauge!(
+        "executor_task.mean_long_delay_duration",
+        "uptime_region" => region.clone(),
+    )
+    .set(interval.mean_long_delay_duration());
+    metrics::gauge!(
+        "executor_task.mean_short_delay_duration",
+        "uptime_region" => region.clone(),
+    )
+    .set(interval.mean_short_delay_duration());
+    metrics::gauge!(
+        "executor_task.mean_long_delay_duration",
+        "uptime_region" => region.clone(),
+    )
+    .set(interval.mean_long_delay_duration());
+}
+
 #[cfg(test)]
 mod tests {
     use std::{task::Poll, time::Duration};
@@ -347,7 +408,13 @@ mod tests {
         let checker = Arc::new(dummy_checker);
         let producer = Arc::new(DummyResultsProducer::new("uptime-results"));
 
-        let (sender, _) = run_executor(1, 0, checker, producer, "us-west".to_string());
+        let conf = ExecutorConfig {
+            concurrency: 1,
+            failure_retries: 0,
+            region: "us-west".to_string(),
+            record_task_metrics: false,
+        };
+        let (sender, _) = run_executor(checker, producer, conf);
 
         let tick = Tick::from_time(Utc::now());
         let config = Arc::new(CheckConfig {
@@ -384,7 +451,13 @@ mod tests {
         let producer = Arc::new(DummyResultsProducer::new("uptime-results"));
 
         // Only allow 2 configs to execute concurrently
-        let (sender, _) = run_executor(2, 0, checker, producer, "us-west".to_string());
+        let conf = ExecutorConfig {
+            concurrency: 2,
+            failure_retries: 0,
+            region: "us-west".to_string(),
+            record_task_metrics: false,
+        };
+        let (sender, _) = run_executor(checker, producer, conf);
 
         // Send 4 configs into the executor
         let mut configs: Vec<Receiver<CheckResult>> = (0..4)
@@ -462,7 +535,13 @@ mod tests {
         let checker = Arc::new(dummy_checker);
         let producer = Arc::new(DummyResultsProducer::new("uptime-results"));
 
-        let (sender, _) = run_executor(1, 0, checker, producer, "us-west".to_string());
+        let conf = ExecutorConfig {
+            concurrency: 1,
+            failure_retries: 0,
+            region: "us-west".to_string(),
+            record_task_metrics: false,
+        };
+        let (sender, _) = run_executor(checker, producer, conf);
 
         let tick = Tick::from_time(Utc::now() - TimeDelta::minutes(2));
         let config = Arc::new(CheckConfig {
@@ -497,7 +576,13 @@ mod tests {
         let producer = Arc::new(DummyResultsProducer::new("uptime-results"));
 
         // Allow one retry
-        let (sender, _) = run_executor(1, 1, checker, producer, "us-west".to_string());
+        let conf = ExecutorConfig {
+            concurrency: 1,
+            failure_retries: 1,
+            region: "us-west".to_string(),
+            record_task_metrics: false,
+        };
+        let (sender, _) = run_executor(checker, producer, conf);
 
         let tick = Tick::from_time(Utc::now());
         let config = Arc::new(CheckConfig {
@@ -537,7 +622,13 @@ mod tests {
         let producer = Arc::new(DummyResultsProducer::new("uptime-results"));
 
         // Allow two retries
-        let (sender, _) = run_executor(1, 2, checker, producer, "us-west".to_string());
+        let conf = ExecutorConfig {
+            concurrency: 1,
+            failure_retries: 2,
+            region: "us-west".to_string(),
+            record_task_metrics: false,
+        };
+        let (sender, _) = run_executor(checker, producer, conf);
 
         let tick = Tick::from_time(Utc::now());
         let config = Arc::new(CheckConfig {


### PR DESCRIPTION
This should help us to understand if our http checker tasks are taking a suspiciously long time to be scheduled or polled.

Our suspicion is that when we turn up execution concurrency we may be overloading the tokio scheduler in a way such that we are very slow to poll the http tasks. By the time we finally poll the task the reqwest timeout may have been reached and the request will be considered timed out.