### PR TITLE
feat(uptime): Allow dns nameservers to be specified for the http checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.12.2"
-source = "git+https://github.com/getsentry/reqwest-uptime?rev=012bc30a15cead582fc770a1a2ff76bc8c800ae5#012bc30a15cead582fc770a1a2ff76bc8c800ae5"
+source = "git+https://github.com/getsentry/reqwest-uptime?rev=be34e1e20c88190dfd46dd609f43aeb15e9ede1b#be34e1e20c88190dfd46dd609f43aeb15e9ede1b"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ hostname = "0.4.0"
 tokio-metrics = "0.4.0"
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }
-reqwest = { git = "https://github.com/getsentry/reqwest-uptime", rev = "012bc30a15cead582fc770a1a2ff76bc8c800ae5" }
-# we're using the jferg/log-dns-timing branch on the reqwest-uptime fork
+reqwest = { git = "https://github.com/getsentry/reqwest-uptime", rev = "be34e1e20c88190dfd46dd609f43aeb15e9ede1b" }
+# we're using the danf/hickory-dns-nameservers branch on the reqwest-uptime fork
 
 [profile.release]
 lto = true

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,5 +1,5 @@
 use std::{borrow::Cow, collections::BTreeMap, net::SocketAddr};
-
+use std::net::IpAddr;
 use figment::{
     providers::{Env, Format, Serialized, Yaml},
     Figment,
@@ -121,6 +121,10 @@ pub struct Config {
 
     /// The number of times to retry failed checks before reporting them as failed
     pub failure_retries: u16,
+
+    /// DNS name servers to use when making checks in the http checker
+    #[serde_as(as = "Option<serde_with::StringWithSeparator::<CommaSeparator, std::net::IpAddr>>")]
+    pub http_checker_dns_nameservers: Option<Vec<IpAddr>>,
 }
 
 impl Default for Config {
@@ -154,6 +158,7 @@ impl Default for Config {
             checker_number: 0,
             total_checkers: 1,
             failure_retries: 0,
+            http_checker_dns_nameservers: None,
         }
     }
 }
@@ -186,7 +191,7 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use std::{borrow::Cow, collections::BTreeMap, path::PathBuf};
-
+    use std::net::IpAddr;
     use figment::Jail;
     use similar_asserts::assert_eq;
 
@@ -274,6 +279,7 @@ mod tests {
                         vector_batch_size: 10,
                         vector_endpoint: "http://localhost:8020".to_owned(),
                         failure_retries: 0,
+                        http_checker_dns_nameservers: None,
                     }
                 );
             },
@@ -314,6 +320,7 @@ mod tests {
                 ("UPTIME_CHECKER_CHECKER_NUMBER", "2"),
                 ("UPTIME_CHECKER_TOTAL_CHECKERS", "5"),
                 ("UPTIME_CHECKER_FAILURE_RETRIES", "2"),
+                ("UPTIME_CHECKER_HTTP_CHECKER_DNS_NAMESERVERS", "8.8.8.8,8.8.4.4")
             ],
             |config| {
                 assert_eq!(
@@ -350,6 +357,7 @@ mod tests {
                         vector_batch_size: 10,
                         vector_endpoint: "http://localhost:8020".to_owned(),
                         failure_retries: 2,
+                        http_checker_dns_nameservers: Some(vec![IpAddr::from([8,8,8,8]), IpAddr::from([8,8,4,4])]),
                     }
                 );
             },

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -113,6 +113,7 @@ impl Manager {
             !config.allow_internal_ips,
             config.disable_connection_reuse,
             Duration::from_secs(config.pool_idle_timeout_secs),
+            config.http_checker_dns_nameservers.clone(),
         ));
 
         let executor_conf = ExecutorConfig {


### PR DESCRIPTION
This allows us to point our http checker at a different dns server. This should allow us to circumvent kube-dns for our checks, which will hopefully resolve a lot of dns issues we've been seeing.