### PR TITLE
feat(http): Implement Isahc HTTP checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -454,7 +454,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -615,6 +615,12 @@ checksum = "2f338b979d9ebfff4bb9801ae8f3af0dc3615f7f1ca963f2e4782bcf9acb3753"
 dependencies = [
  "crossbeam-channel",
 ]
+
+[[package]]
+name = "castaway"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
@@ -820,6 +826,37 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.72",
+]
+
+[[package]]
+name = "curl"
+version = "0.4.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9fb4d13a1be2b58f14d60adba57c9834b78c62fd86c3e76a148f732686e9265"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2 0.5.7",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.80+curl-8.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f7df2eac63200c3ab25bde3b2268ef2ee56af3d238e76d61f01c3c49bff734"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1294,7 +1331,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http 1.2.0",
  "indexmap 2.3.0",
  "slab",
  "tokio",
@@ -1437,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -1464,7 +1501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -1475,7 +1512,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1553,7 +1590,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -1602,7 +1639,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "hyper 1.4.1",
  "pin-project-lite",
@@ -1853,6 +1890,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "isahc"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
+dependencies = [
+ "async-channel 1.9.0",
+ "castaway",
+ "crossbeam-utils",
+ "curl",
+ "curl-sys",
+ "encoding_rs",
+ "event-listener 2.5.3",
+ "futures-lite 1.13.0",
+ "http 0.2.12",
+ "log",
+ "mime",
+ "once_cell",
+ "polling 2.8.0",
+ "slab",
+ "sluice",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "waker-fn",
+]
+
+[[package]]
 name = "iso8601"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2058,16 @@ checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "libnghttp2-sys"
+version = "0.1.11+1.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6c24e48a7167cffa7119da39d577fa482e66c688a4aac016bee862e1a713c4"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -2890,7 +2964,7 @@ dependencies = [
  "futures-util",
  "h2",
  "hickory-resolver",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
@@ -3631,6 +3705,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sluice"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
+dependencies = [
+ "async-channel 1.9.0",
+ "futures-core",
+ "futures-io",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3998,7 +4083,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.1.0",
+ "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
@@ -4068,6 +4153,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4092,6 +4178,16 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -4280,10 +4376,12 @@ dependencies = [
  "futures",
  "hickory-resolver",
  "hostname 0.4.0",
+ "http 1.2.0",
  "httpmock",
  "hyper 1.4.1",
  "hyper-util",
  "ipnet",
+ "isahc",
  "metrics",
  "metrics-exporter-statsd",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ time = "0.3"
 ctor = "0.2"
 hostname = "0.4.0"
 tokio-metrics = "0.4.0"
+isahc = "1.7.2"
+http = "1.2.0"
 [patch.crates-io]
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka" }
 reqwest = { git = "https://github.com/getsentry/reqwest-uptime", rev = "be34e1e20c88190dfd46dd609f43aeb15e9ede1b" }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -25,6 +25,13 @@ pub enum ProducerMode {
     Vector,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckerMode {
+    Reqwest,
+    Isahc,
+}
+
 #[serde_as]
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 pub struct MetricsConfig {
@@ -77,6 +84,9 @@ pub struct Config {
 
     /// Which config provider to use to load configs into memory
     pub config_provider_mode: ConfigProviderMode,
+
+    /// Which checker implementation to use to run the HTTP checks.
+    pub checker_mode: CheckerMode,
 
     /// which producer to use to send results
     pub producer_mode: ProducerMode,
@@ -151,6 +161,7 @@ impl Default for Config {
             results_kafka_cluster: vec![],
             results_kafka_topic: "uptime-results".to_owned(),
             config_provider_mode: ConfigProviderMode::Redis,
+            checker_mode: CheckerMode::Reqwest,
             vector_batch_size: 10,
             vector_endpoint: "http://localhost:8020".to_owned(),
             producer_mode: ProducerMode::Kafka,
@@ -222,12 +233,9 @@ mod tests {
     use std::net::IpAddr;
     use std::{borrow::Cow, collections::BTreeMap, path::PathBuf};
 
-    use crate::{
-        app::{cli, config::ProducerMode},
-        logging,
-    };
+    use crate::{app::cli, logging};
 
-    use super::{Config, ConfigProviderMode, MetricsConfig};
+    use super::{CheckerMode, Config, ConfigProviderMode, MetricsConfig, ProducerMode};
 
     fn test_with_config<F>(yaml: &str, env_vars: &[(&str, &str)], test_fn: F)
     where
@@ -292,6 +300,7 @@ mod tests {
                         ],
                         results_kafka_topic: "uptime-results".to_owned(),
                         config_provider_mode: ConfigProviderMode::Redis,
+                        checker_mode: CheckerMode::Reqwest,
                         config_provider_redis_update_ms: 1000,
                         config_provider_redis_total_partitions: 128,
                         redis_enable_cluster: false,
@@ -377,6 +386,7 @@ mod tests {
                         ],
                         results_kafka_topic: "uptime-results".to_owned(),
                         config_provider_mode: ConfigProviderMode::Redis,
+                        checker_mode: CheckerMode::Reqwest,
                         config_provider_redis_update_ms: 2000,
                         config_provider_redis_total_partitions: 32,
                         redis_enable_cluster: true,

--- a/src/checker/isahc_checker.rs
+++ b/src/checker/isahc_checker.rs
@@ -1,0 +1,763 @@
+use super::{make_trace_header, make_trace_id, Checker};
+use crate::config_store::Tick;
+use crate::types::{
+    check_config::CheckConfig,
+    result::{CheckResult, CheckStatus, CheckStatusReason, CheckStatusReasonType, RequestInfo},
+};
+use chrono::{TimeDelta, Utc};
+use http::Method;
+use isahc::config::{Configurable, NetworkInterface, RedirectPolicy};
+use isahc::error::ErrorKind;
+use isahc::{AsyncBody, HttpClient, Request, Response};
+use sentry::protocol::SpanId;
+use std::time::Duration;
+use tokio::time::Instant;
+
+const UPTIME_USER_AGENT: &str =
+    "SentryUptimeBot/1.0 (+http://docs.sentry.io/product/alerts/uptime-monitoring/)";
+
+/// Responsible for making HTTP requests to check if a domain is up.
+#[derive(Clone, Debug)]
+pub struct IsahcChecker {
+    client: HttpClient,
+}
+
+struct Options {
+    /// Specifies the network interface to bind the client to.
+    interface: Option<String>,
+
+    /// Set the maximum time-to-live (TTL) for connections to remain in the connection cache.
+    connection_cache_ttl: Duration,
+
+    /// When set to true sets the connection_cache_size to 0. Effectively removing connection
+    /// pooling and forcing a new connection for each new request. This may help reduce connection
+    /// errors due to connections being held open too long.
+    disable_connection_reuse: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            interface: None,
+            connection_cache_ttl: Duration::from_secs(90),
+            disable_connection_reuse: false,
+        }
+    }
+}
+
+/// Fetches the response from a URL.
+async fn do_request(
+    client: &HttpClient,
+    check_config: &CheckConfig,
+    sentry_trace: &str,
+) -> Result<Response<AsyncBody>, isahc::Error> {
+    let timeout = check_config
+        .timeout
+        .to_std()
+        .expect("Timeout duration could not be converted to std::time::Duration");
+
+    let url = check_config.url.as_str();
+
+    let mut request_builder = Request::builder()
+        .timeout(timeout)
+        .method(Method::from(check_config.request_method).as_str())
+        .uri(url)
+        .header("sentry-trace", sentry_trace.to_owned());
+
+    for (key, value) in &check_config.request_headers {
+        request_builder = request_builder.header(key, value);
+    }
+
+    let request = request_builder.body(check_config.request_body.to_owned())?;
+
+    client.send_async(request).await
+}
+
+impl IsahcChecker {
+    fn new_internal(options: Options) -> Self {
+        let mut builder = HttpClient::builder()
+            .default_headers(&[("User-Agent", UPTIME_USER_AGENT)])
+            .connection_cache_ttl(options.connection_cache_ttl)
+            .redirect_policy(RedirectPolicy::Limit(9));
+
+        if options.disable_connection_reuse {
+            builder = builder.connection_cache_size(0);
+        }
+
+        if let Some(nic) = options.interface {
+            builder = builder.interface(NetworkInterface::name(nic))
+        }
+
+        let client = builder.build().expect("Failed to build checker client");
+
+        Self { client }
+    }
+
+    pub fn new(
+        disable_connection_reuse: bool,
+        connection_cache_ttl: Duration,
+        interface: Option<String>,
+    ) -> Self {
+        Self::new_internal(Options {
+            disable_connection_reuse,
+            connection_cache_ttl,
+            interface,
+        })
+    }
+}
+
+impl Checker for IsahcChecker {
+    /// Makes a request to a url to determine whether it is up.
+    /// Up is defined as returning a 2xx within a specific timeframe.
+    #[tracing::instrument]
+    async fn check_url(&self, config: &CheckConfig, tick: &Tick, region: &str) -> CheckResult {
+        let scheduled_check_time = tick.time();
+        let actual_check_time = Utc::now();
+        let span_id = SpanId::default();
+        let trace_id = make_trace_id(config, tick);
+        let trace_header = make_trace_header(config, &trace_id, span_id);
+
+        let start = Instant::now();
+        let response = do_request(&self.client, config, &trace_header).await;
+        let duration = Some(TimeDelta::from_std(start.elapsed()).unwrap());
+
+        let status = if response.as_ref().is_ok_and(|r| r.status().is_success()) {
+            CheckStatus::Success
+        } else {
+            CheckStatus::Failure
+        };
+
+        let http_status_code = match &response {
+            Ok(r) => Some(r.status().as_u16()),
+            Err(_) => None,
+        };
+
+        let request_info = Some(RequestInfo {
+            http_status_code,
+            request_type: config.request_method,
+        });
+
+        let status_reason = match response {
+            Ok(r) if r.status().is_success() => None,
+            Ok(r) => Some(CheckStatusReason {
+                status_type: CheckStatusReasonType::Failure,
+                description: format!("Got non 2xx status: {}", r.status()),
+            }),
+            Err(e) => Some({
+                match e.kind() {
+                    ErrorKind::Timeout => CheckStatusReason {
+                        status_type: CheckStatusReasonType::Timeout,
+                        description: e.to_string(),
+                    },
+                    ErrorKind::TooManyRedirects => CheckStatusReason {
+                        status_type: CheckStatusReasonType::RedirectError,
+                        description: "Too many redirects".to_string(),
+                    },
+                    ErrorKind::NameResolution => CheckStatusReason {
+                        status_type: CheckStatusReasonType::DnsError,
+                        description: e.to_string(),
+                    },
+                    ErrorKind::BadClientCertificate
+                    | ErrorKind::BadServerCertificate
+                    | ErrorKind::TlsEngine => CheckStatusReason {
+                        status_type: CheckStatusReasonType::TlsError,
+                        description: e.to_string(),
+                    },
+                    ErrorKind::ConnectionFailed | ErrorKind::Io => CheckStatusReason {
+                        status_type: CheckStatusReasonType::ConnectionError,
+                        description: e.to_string(),
+                    },
+                    _ => {
+                        // if any error falls through we should log it,
+                        // none should fall through.
+                        let error_msg = e.to_string();
+                        tracing::info!("check_url.error: {:?}", error_msg);
+                        CheckStatusReason {
+                            status_type: CheckStatusReasonType::Failure,
+                            description: format!("{:?}", error_msg),
+                        }
+                    }
+                }
+            }),
+        };
+
+        CheckResult {
+            guid: trace_id,
+            subscription_id: config.subscription_id,
+            status,
+            status_reason,
+            trace_id,
+            span_id,
+            scheduled_check_time,
+            actual_check_time,
+            duration,
+            request_info,
+            region: region.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::checker::Checker;
+    use crate::config_store::Tick;
+    use crate::types::check_config::CheckConfig;
+    use crate::types::result::{CheckStatus, CheckStatusReasonType};
+    use crate::types::shared::RequestMethod;
+    use std::time::Duration;
+
+    use super::{make_trace_header, IsahcChecker, Options, UPTIME_USER_AGENT};
+    use chrono::{TimeDelta, Utc};
+    use httpmock::prelude::*;
+    use httpmock::Method;
+
+    use sentry::protocol::SpanId;
+    use uuid::Uuid;
+    #[cfg(target_os = "linux")]
+    use {
+        rcgen::{Certificate, CertificateParams},
+        rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
+        rustls::ServerConfig,
+        std::sync::Arc,
+        tokio::io::AsyncWriteExt,
+        tokio::net::TcpListener,
+        tokio_rustls::TlsAcceptor,
+    };
+
+    fn make_tick() -> Tick {
+        Tick::from_time(Utc::now() - TimeDelta::seconds(60))
+    }
+
+    #[tokio::test]
+    async fn test_default_get() {
+        let server = MockServer::start();
+        let checker = IsahcChecker::new_internal(Options {
+            disable_connection_reuse: true,
+            connection_cache_ttl: Duration::from_secs(90),
+            interface: None,
+        });
+
+        let get_mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/no-head")
+                .header_exists("sentry-trace")
+                .header("User-Agent", UPTIME_USER_AGENT.to_string());
+            then.status(200);
+        });
+
+        let config = CheckConfig {
+            url: server.url("/no-head").to_string(),
+            ..Default::default()
+        };
+
+        let tick = make_tick();
+        let result = checker.check_url(&config, &tick, "us-west").await;
+
+        assert_eq!(result.status, CheckStatus::Success);
+        assert_eq!(
+            result.request_info.as_ref().map(|i| i.request_type),
+            Some(RequestMethod::Get)
+        );
+
+        get_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_configured_post() {
+        let server = MockServer::start();
+        let checker = IsahcChecker::new_internal(Options {
+            disable_connection_reuse: true,
+            connection_cache_ttl: Duration::from_secs(90),
+            interface: None,
+        });
+
+        let get_mock = server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/no-head")
+                .header_exists("sentry-trace")
+                .body("{\"key\":\"value\"}")
+                .header("User-Agent", UPTIME_USER_AGENT.to_string())
+                .header("Authorization", "Bearer my-token".to_string())
+                .header("X-My-Custom-Header", "value".to_string());
+            then.status(200);
+        });
+
+        let config = CheckConfig {
+            url: server.url("/no-head").to_string(),
+            request_method: RequestMethod::Post,
+            request_headers: vec![
+                ("Authorization".to_string(), "Bearer my-token".to_string()),
+                ("X-My-Custom-Header".to_string(), "value".to_string()),
+            ],
+            request_body: "{\"key\":\"value\"}".to_string(),
+            ..Default::default()
+        };
+
+        let tick = make_tick();
+        let result = checker.check_url(&config, &tick, "us-west").await;
+
+        assert_eq!(result.status, CheckStatus::Success);
+        assert_eq!(
+            result.request_info.as_ref().map(|i| i.request_type),
+            Some(RequestMethod::Post)
+        );
+
+        get_mock.assert();
+    }
+    #[tokio::test]
+    async fn test_simple_timeout() {
+        static TIMEOUT: i64 = 200;
+
+        let server = MockServer::start();
+
+        let timeout = TimeDelta::milliseconds(TIMEOUT);
+        let checker = IsahcChecker::new_internal(Options {
+            disable_connection_reuse: true,
+            connection_cache_ttl: Duration::from_secs(90),
+            interface: None,
+        });
+
+        let timeout_mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/timeout")
+                .header_exists("sentry-trace");
+            then.delay((timeout + TimeDelta::milliseconds(200)).to_std().unwrap())
+                .status(200);
+        });
+
+        let config = CheckConfig {
+            url: server.url("/timeout").to_string(),
+            timeout,
+            ..Default::default()
+        };
+
+        let tick = make_tick();
+        let result = checker.check_url(&config, &tick, "us-west").await;
+
+        assert_eq!(result.status, CheckStatus::Failure);
+        assert!(result.duration.is_some_and(|d| d > timeout));
+        assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
+        assert_eq!(
+            result.status_reason.as_ref().map(|r| r.description.clone()),
+            Some("request or operation took longer than the configured timeout time".to_string())
+        );
+        assert_eq!(
+            result.status_reason.map(|r| r.status_type),
+            Some(CheckStatusReasonType::Timeout)
+        );
+
+        timeout_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_simple_400() {
+        let server = MockServer::start();
+        let checker = IsahcChecker::new_internal(Options {
+            disable_connection_reuse: true,
+            connection_cache_ttl: Duration::from_secs(90),
+            interface: None,
+        });
+
+        let head_mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/get")
+                .header_exists("sentry-trace");
+            then.status(400);
+        });
+
+        let config = CheckConfig {
+            url: server.url("/get").to_string(),
+            ..Default::default()
+        };
+
+        let tick = make_tick();
+        let result = checker.check_url(&config, &tick, "us-west").await;
+
+        assert_eq!(result.status, CheckStatus::Failure);
+        assert_eq!(
+            result.request_info.and_then(|i| i.http_status_code),
+            Some(400)
+        );
+        assert_eq!(
+            result.status_reason.as_ref().map(|r| r.status_type),
+            Some(CheckStatusReasonType::Failure)
+        );
+        assert_eq!(
+            result.status_reason.map(|r| r.description),
+            Some("Got non 2xx status: 400 Bad Request".to_string())
+        );
+
+        head_mock.assert();
+    }
+
+    //#[tokio::test]
+    //async fn test_restricted_resolution() {
+    //    let checker = IsahcChecker::new_internal(Options {
+    //        validate_url: true,
+    //        disable_connection_reuse: true,
+    //        pool_idle_timeout: Duration::from_secs(90),
+    //        interface: None,
+    //    });
+    //
+    //    let localhost_config = CheckConfig {
+    //        url: "http://localhost/whatever".to_string(),
+    //        ..Default::default()
+    //    };
+    //
+    //    let tick = make_tick();
+    //    let result = checker.check_url(&localhost_config, &tick, "us-west").await;
+    //
+    //    assert_eq!(result.status, CheckStatus::Failure);
+    //    assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
+    //
+    //    assert_eq!(
+    //        result.status_reason.as_ref().map(|r| r.status_type),
+    //        Some(CheckStatusReasonType::DnsError)
+    //    );
+    //    assert_eq!(
+    //        result.status_reason.map(|r| r.description),
+    //        Some("destination is restricted".to_string())
+    //    );
+    //}
+    //
+    //#[tokio::test]
+    //async fn test_validate_url() {
+    //    let checker = IsahcChecker::new_internal(Options {
+    //        validate_url: true,
+    //        disable_connection_reuse: true,
+    //        pool_idle_timeout: Duration::from_secs(90),
+    //        interface: None,
+    //    });
+    //
+    //    // Private address space
+    //    let restricted_ip_config = CheckConfig {
+    //        url: "http://10.0.0.1/".to_string(),
+    //        ..Default::default()
+    //    };
+    //    let tick = make_tick();
+    //    let result = checker
+    //        .check_url(&restricted_ip_config, &tick, "us-west")
+    //        .await;
+    //
+    //    assert_eq!(result.status, CheckStatus::Failure);
+    //    assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
+    //
+    //    assert_eq!(
+    //        result.status_reason.as_ref().map(|r| r.status_type),
+    //        Some(CheckStatusReasonType::DnsError)
+    //    );
+    //    assert_eq!(
+    //        result.status_reason.map(|r| r.description),
+    //        Some("destination is restricted".to_string())
+    //    );
+    //
+    //    // Unique Local Address
+    //    let restricted_ipv6_config = CheckConfig {
+    //        url: "http://[fd12:3456:789a:1::1]/".to_string(),
+    //        ..Default::default()
+    //    };
+    //    let tick = make_tick();
+    //    let result = checker
+    //        .check_url(&restricted_ipv6_config, &tick, "us-west")
+    //        .await;
+    //    assert_eq!(
+    //        result.status_reason.map(|r| r.description),
+    //        Some("destination is restricted".to_string())
+    //    );
+    //}
+
+    #[tokio::test]
+    async fn test_same_check_same_id() {
+        let server = MockServer::start();
+        let checker = IsahcChecker::new_internal(Options {
+            disable_connection_reuse: true,
+            connection_cache_ttl: Duration::from_secs(90),
+            interface: None,
+        });
+
+        let get_mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/no-head")
+                .header_exists("sentry-trace")
+                .header("User-Agent", UPTIME_USER_AGENT.to_string());
+            then.status(200);
+        });
+
+        let config = CheckConfig {
+            url: server.url("/no-head").to_string(),
+            ..Default::default()
+        };
+
+        let tick = make_tick();
+        let result = checker.check_url(&config, &tick, "us-west").await;
+        let result_2 = checker.check_url(&config, &tick, "us-west").await;
+
+        assert_eq!(result.status, CheckStatus::Success);
+        assert_eq!(result_2.status, CheckStatus::Success);
+        assert_eq!(result.guid, result_2.guid);
+        assert_eq!(result.trace_id, result_2.trace_id);
+        get_mock.assert_hits(2);
+    }
+
+    #[tokio::test]
+    async fn test_trace_sampling() {
+        let trace_id = Uuid::new_v4();
+        let span_id = SpanId::default();
+
+        // Test with sampling disabled
+        let config = CheckConfig {
+            url: "http://localhost/".to_string(),
+            trace_sampling: false,
+            ..Default::default()
+        };
+        let trace_header = make_trace_header(&config, &trace_id, span_id);
+        assert_eq!(trace_header, format!("{}-{}-0", trace_id.simple(), span_id));
+        assert_eq!(trace_header.to_string().matches("-").count(), 2);
+
+        // Test with sampling enabled
+        let config_with_sampling = CheckConfig {
+            url: "http://localhost/".to_string(),
+            trace_sampling: true,
+            ..Default::default()
+        };
+        let trace_header_sampling = make_trace_header(&config_with_sampling, &trace_id, span_id);
+        assert_eq!(
+            trace_header_sampling,
+            format!("{}-{}", trace_id.simple(), span_id)
+        );
+        assert_eq!(trace_header_sampling.to_string().matches("-").count(), 1);
+    }
+
+    #[tokio::test]
+    #[cfg(target_os = "linux")]
+    async fn test_ssl_errors_linux() {
+        #[derive(Debug, Copy, Clone)]
+        enum TestCertType {
+            Expired,
+            WrongHost,
+            SelfSigned,
+        }
+        // Helper function to create various bad certificates
+        fn create_bad_cert(cert_type: TestCertType) -> (Vec<u8>, Vec<u8>) {
+            let mut params = CertificateParams::new(vec!["localhost".to_string()]);
+            match cert_type {
+                TestCertType::Expired => {
+                    params.not_before = time::OffsetDateTime::now_utc() - time::Duration::days(30);
+                    params.not_after = time::OffsetDateTime::now_utc() - time::Duration::days(1);
+                }
+                TestCertType::WrongHost => {
+                    params = CertificateParams::new(vec!["wronghost.com".to_string()]);
+                }
+                TestCertType::SelfSigned => {
+                    // Default params are self-signed
+                }
+            }
+
+            let cert = Certificate::from_params(params).unwrap();
+            (
+                cert.serialize_private_key_der(),
+                cert.serialize_der().unwrap(),
+            )
+        }
+
+        // Set up mock HTTPS server
+        async fn setup_test_server(cert_type: TestCertType) -> String {
+            let (key_der, cert_der) = create_bad_cert(cert_type);
+
+            let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_der));
+            let cert = vec![CertificateDer::from(cert_der)];
+
+            let server_config = ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(cert, key)
+                .unwrap();
+
+            let acceptor = TlsAcceptor::from(Arc::new(server_config));
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+
+            tokio::spawn(async move {
+                while let Ok((stream, _)) = listener.accept().await {
+                    let acceptor = acceptor.clone();
+                    tokio::spawn(async move {
+                        if let Ok(mut tls_stream) = acceptor.accept(stream).await {
+                            // Simple HTTP response
+                            let response = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+                            let _ = tls_stream.write_all(response).await;
+                        }
+                    });
+                }
+            });
+
+            format!("https://localhost:{}", addr.port())
+        }
+
+        let checker = IsahcChecker::new_internal(Options {
+            disable_connection_reuse: true,
+            connection_cache_ttl: Duration::from_secs(90),
+            interface: None,
+        });
+        let tick = make_tick();
+
+        // Test various SSL certificate errors
+        let test_cases = vec![
+            (
+                TestCertType::Expired,
+                "the server certificate could not be validated",
+            ),
+            (
+                TestCertType::WrongHost,
+                "the server certificate could not be validated",
+            ),
+            (
+                TestCertType::SelfSigned,
+                "the server certificate could not be validated",
+            ),
+        ];
+
+        for (cert_type, expected_msg) in test_cases {
+            let server_url = setup_test_server(cert_type).await;
+
+            let config = CheckConfig {
+                url: server_url,
+                ..Default::default()
+            };
+
+            let result = checker.check_url(&config, &tick, "us-west").await;
+
+            assert_eq!(
+                result.status,
+                CheckStatus::Failure,
+                "Test case: {:?}",
+                &cert_type
+            );
+            assert_eq!(
+                result.request_info.and_then(|i| i.http_status_code),
+                None,
+                "Test case: {:?}",
+                cert_type
+            );
+            assert_eq!(
+                result.status_reason.as_ref().map(|r| r.status_type),
+                Some(CheckStatusReasonType::TlsError),
+                "Test case: {:?}",
+                cert_type
+            );
+            assert_eq!(
+                result.status_reason.map(|r| r.description).unwrap(),
+                expected_msg,
+                "Test case: {:?}",
+                cert_type
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_connection_refused() {
+        let checker = IsahcChecker::new_internal(Options {
+            disable_connection_reuse: true,
+            connection_cache_ttl: Duration::from_secs(90),
+            interface: None,
+        });
+        let tick = make_tick();
+        let config = CheckConfig {
+            url: "http://localhost:12345/".to_string(),
+            ..Default::default()
+        };
+        let result = checker.check_url(&config, &tick, "us-west").await;
+        assert_eq!(result.status, CheckStatus::Failure);
+        assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
+        assert_eq!(
+            result.status_reason.as_ref().map(|r| r.status_type),
+            Some(CheckStatusReasonType::ConnectionError)
+        );
+        assert_eq!(
+            result.status_reason.map(|r| r.description),
+            Some("failed to connect to the server".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_too_many_redirects() {
+        let server = MockServer::start();
+        let checker = IsahcChecker::new_internal(Options {
+            disable_connection_reuse: true,
+            connection_cache_ttl: Duration::from_secs(90),
+            interface: None,
+        });
+
+        // Create a redirect loop where each request redirects back to itself
+        let redirect_mock = server.mock(|when, then| {
+            when.method(Method::GET)
+                .path("/redirect")
+                .header_exists("sentry-trace");
+            then.status(302)
+                .header("Location", server.url("/redirect").as_str());
+        });
+
+        let config = CheckConfig {
+            url: server.url("/redirect").to_string(),
+            ..Default::default()
+        };
+
+        let tick = make_tick();
+        let result = checker.check_url(&config, &tick, "us-west").await;
+
+        assert_eq!(result.status, CheckStatus::Failure);
+        assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
+        assert_eq!(
+            result.status_reason.as_ref().map(|r| r.status_type),
+            Some(CheckStatusReasonType::RedirectError)
+        );
+        assert_eq!(
+            result.status_reason.map(|r| r.description),
+            Some("Too many redirects".to_string())
+        );
+
+        // Verify that the mock was called at least once
+        // The reqwest client follows redirects multiple times before giving up
+        redirect_mock.assert_hits(10);
+    }
+
+    #[tokio::test]
+    #[cfg(target_os = "linux")]
+    async fn test_connection_reset() {
+        // Set up a TCP listener that sends an incomplete response
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                // Send an incomplete HTTP response - just the headers
+                let partial_response: &[u8; 38] = b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\n";
+                let _ = stream.write_all(partial_response).await;
+                // Close connection immediately without sending body or final \r\n
+            }
+        });
+
+        let checker = IsahcChecker::new_internal(Options {
+            disable_connection_reuse: true,
+            connection_cache_ttl: Duration::from_secs(90),
+            interface: None,
+        });
+        let tick = make_tick();
+        let config = CheckConfig {
+            url: format!("http://localhost:{}", addr.port()),
+            ..Default::default()
+        };
+        let result = checker.check_url(&config, &tick, "us-west").await;
+
+        assert_eq!(result.status, CheckStatus::Failure);
+        assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
+        assert_eq!(
+            result.status_reason.as_ref().map(|r| r.status_type),
+            Some(CheckStatusReasonType::ConnectionError)
+        );
+        let result_description = result.status_reason.map(|r| r.description).unwrap();
+        assert_eq!(
+            result_description, "unknown error",
+            "Expected error message about closed connection: {}",
+            result_description
+        );
+    }
+}

--- a/src/checker/reqwest_checker.rs
+++ b/src/checker/reqwest_checker.rs
@@ -20,7 +20,7 @@ const UPTIME_USER_AGENT: &str =
 
 /// Responsible for making HTTP requests to check if a domain is up.
 #[derive(Clone, Debug)]
-pub struct HttpChecker {
+pub struct ReqwestChecker {
     client: Client,
 }
 
@@ -166,7 +166,7 @@ fn hyper_util_error(err: &reqwest::Error) -> Option<(CheckStatusReasonType, Stri
     None
 }
 
-impl HttpChecker {
+impl ReqwestChecker {
     fn new_internal(options: Options) -> Self {
         let mut default_headers = HeaderMap::new();
         default_headers.insert("User-Agent", UPTIME_USER_AGENT.to_string().parse().unwrap());
@@ -216,7 +216,7 @@ impl HttpChecker {
     }
 }
 
-impl Checker for HttpChecker {
+impl Checker for ReqwestChecker {
     /// Makes a request to a url to determine whether it is up.
     /// Up is defined as returning a 2xx within a specific timeframe.
     #[tracing::instrument]
@@ -320,7 +320,6 @@ impl Checker for HttpChecker {
 
 #[cfg(test)]
 mod tests {
-    use crate::checker::http_checker::make_trace_header;
     use crate::checker::Checker;
     use crate::config_store::Tick;
     use crate::types::check_config::CheckConfig;
@@ -329,7 +328,7 @@ mod tests {
     use std::net::IpAddr;
     use std::time::Duration;
 
-    use super::{HttpChecker, Options, UPTIME_USER_AGENT};
+    use super::{make_trace_header, Options, ReqwestChecker, UPTIME_USER_AGENT};
     use chrono::{TimeDelta, Utc};
     use httpmock::prelude::*;
     use httpmock::Method;
@@ -354,7 +353,7 @@ mod tests {
     #[tokio::test]
     async fn test_default_get() {
         let server = MockServer::start();
-        let checker = HttpChecker::new_internal(Options {
+        let checker = ReqwestChecker::new_internal(Options {
             validate_url: false,
             disable_connection_reuse: true,
             dns_nameservers: None,
@@ -390,7 +389,7 @@ mod tests {
     #[tokio::test]
     async fn test_configured_post() {
         let server = MockServer::start();
-        let checker = HttpChecker::new_internal(Options {
+        let checker = ReqwestChecker::new_internal(Options {
             validate_url: false,
             disable_connection_reuse: true,
             dns_nameservers: None,
@@ -438,7 +437,7 @@ mod tests {
         let server = MockServer::start();
 
         let timeout = TimeDelta::milliseconds(TIMEOUT);
-        let checker = HttpChecker::new_internal(Options {
+        let checker = ReqwestChecker::new_internal(Options {
             validate_url: false,
             disable_connection_reuse: true,
             dns_nameservers: None,
@@ -481,7 +480,7 @@ mod tests {
     #[tokio::test]
     async fn test_simple_400() {
         let server = MockServer::start();
-        let checker = HttpChecker::new_internal(Options {
+        let checker = ReqwestChecker::new_internal(Options {
             validate_url: false,
             disable_connection_reuse: true,
             dns_nameservers: None,
@@ -523,7 +522,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_restricted_resolution() {
-        let checker = HttpChecker::new_internal(Options {
+        let checker = ReqwestChecker::new_internal(Options {
             validate_url: true,
             disable_connection_reuse: true,
             dns_nameservers: None,
@@ -554,7 +553,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_url() {
-        let checker = HttpChecker::new_internal(Options {
+        let checker = ReqwestChecker::new_internal(Options {
             validate_url: true,
             disable_connection_reuse: true,
             dns_nameservers: None,
@@ -602,7 +601,7 @@ mod tests {
     #[tokio::test]
     async fn test_same_check_same_id() {
         let server = MockServer::start();
-        let checker = HttpChecker::new_internal(Options {
+        let checker = ReqwestChecker::new_internal(Options {
             validate_url: false,
             disable_connection_reuse: true,
             dns_nameservers: None,
@@ -727,7 +726,7 @@ mod tests {
             format!("https://localhost:{}", addr.port())
         }
 
-        let checker = HttpChecker::new_internal(Options {
+        let checker = ReqwestChecker::new_internal(Options {
             validate_url: false,
             disable_connection_reuse: true,
             dns_nameservers: None,
@@ -782,7 +781,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_connection_refused() {
-        let checker = HttpChecker::new_internal(Options {
+        let checker = ReqwestChecker::new_internal(Options {
             validate_url: false,
             disable_connection_reuse: true,
             dns_nameservers: None,
@@ -810,7 +809,7 @@ mod tests {
     #[tokio::test]
     async fn test_too_many_redirects() {
         let server = MockServer::start();
-        let checker = HttpChecker::new_internal(Options {
+        let checker = ReqwestChecker::new_internal(Options {
             validate_url: false,
             disable_connection_reuse: true,
             dns_nameservers: None,
@@ -867,7 +866,7 @@ mod tests {
             }
         });
 
-        let checker = HttpChecker::new_internal(Options {
+        let checker = ReqwestChecker::new_internal(Options {
             validate_url: false,
             disable_connection_reuse: true,
             dns_nameservers: None,
@@ -898,7 +897,7 @@ mod tests {
     #[tokio::test]
     async fn test_dns_nameservers() {
         let server = MockServer::start();
-        let checker = HttpChecker::new_internal(Options {
+        let checker = ReqwestChecker::new_internal(Options {
             dns_nameservers: Some(vec![IpAddr::from([42, 55, 6, 8])]),
             validate_url: false,
             ..Default::default()

--- a/src/types/shared.rs
+++ b/src/types/shared.rs
@@ -25,16 +25,16 @@ impl Default for RequestMethod {
     }
 }
 
-impl From<RequestMethod> for reqwest::Method {
+impl From<RequestMethod> for http::Method {
     fn from(value: RequestMethod) -> Self {
         match value {
-            RequestMethod::Get => reqwest::Method::GET,
-            RequestMethod::Post => reqwest::Method::POST,
-            RequestMethod::Head => reqwest::Method::HEAD,
-            RequestMethod::Put => reqwest::Method::PUT,
-            RequestMethod::Delete => reqwest::Method::DELETE,
-            RequestMethod::Patch => reqwest::Method::PATCH,
-            RequestMethod::Options => reqwest::Method::OPTIONS,
+            RequestMethod::Get => http::Method::GET,
+            RequestMethod::Post => http::Method::POST,
+            RequestMethod::Head => http::Method::HEAD,
+            RequestMethod::Put => http::Method::PUT,
+            RequestMethod::Delete => http::Method::DELETE,
+            RequestMethod::Patch => http::Method::PATCH,
+            RequestMethod::Options => http::Method::OPTIONS,
         }
     }
 }


### PR DESCRIPTION
Adds a new Isahc HTTP checker.

We would like to experiment with this checker to collect better metrics
about the HTTP requets being made.

There are a few things we still need to fix before we can enable this

- [ ] We need some way to restrict (See internal https://getsentry.atlassian.net/jira/servicedesk/projects/INF/issues/INF-449)
- [ ] We need to be able to configure the DNS servers since our kube-dns
      is flakey. See https://github.com/sagebind/isahc/issues/364