### PR TITLE
fix(uptime): Add curl to deploy image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apk add --no-cache \
     g++ \
     pkgconfig \
     openssl-dev \
-    curl \
     protoc
 
 # Configure cargo
@@ -45,7 +44,7 @@ FROM alpine:3.20
 
 COPY --from=builder /app/target/release/uptime-checker /usr/local/bin/uptime-checker
 
-RUN apk add --no-cache tini libgcc && \
+RUN apk add --no-cache tini libgcc curl && \
     addgroup -S app && \
     adduser -S app -G app
 


### PR DESCRIPTION
We added this to builder before, but it needs to be in the deploy container