### PR TITLE
fix(uptime): Have uptime-checker shut down gracefully on sigterm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,6 +2265,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntest"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb183f0a1da7a937f672e5ee7b7edb727bf52b8a52d531374ba8ebb9345c0330"
+dependencies = [
+ "ntest_test_cases",
+ "ntest_timeout",
+]
+
+[[package]]
+name = "ntest_test_cases"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d0d3f2a488592e5368ebbe996e7f1d44aa13156efad201f5b4d84e150eaa93"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ntest_timeout"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc7c92f190c97f79b4a332f5e81dcf68c8420af2045c936c9be0bc9de6f63b5"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4384,6 +4417,7 @@ dependencies = [
  "isahc",
  "metrics",
  "metrics-exporter-statsd",
+ "ntest",
  "openssl",
  "rcgen",
  "redis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,4 @@ strip = "debuginfo"
 
 [dev-dependencies]
 redis-test-macro = { path = "./redis-test-macro" }
+ntest = "0.9.3"

--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -165,6 +165,7 @@ pub fn run_executor(
     (check_sender, executor_handle)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn executor_loop(
     conf: ExecutorConfig,
     queue_size: Arc<AtomicU64>,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -136,7 +136,7 @@ impl Manager {
         };
 
         let cancel_token = CancellationToken::new();
-        
+
         let (executor_sender, executor_join_handle, results_worker) = match &config.producer_mode {
             ProducerMode::Vector => {
                 let (results_producer, results_worker) = VectorResultsProducer::new(
@@ -147,8 +147,12 @@ impl Manager {
                 let producer = Arc::new(results_producer);
                 // XXX: Executor will shutdown once the sender goes out of scope. This will happen once all
                 // referneces of the Sender (executor_sender) are dropped.
-                let (sender, handle) =
-                    run_executor(checker.clone(), producer, executor_conf, cancel_token.clone());
+                let (sender, handle) = run_executor(
+                    checker.clone(),
+                    producer,
+                    executor_conf,
+                    cancel_token.clone(),
+                );
                 (sender, handle, results_worker)
             }
             ProducerMode::Kafka => {
@@ -164,8 +168,12 @@ impl Manager {
                 ));
                 // XXX: Executor will shutdown once the sender goes out of scope. This will happen once all
                 // referneces of the Sender (executor_sender) are dropped.
-                let (sender, handle) =
-                    run_executor(checker.clone(), producer, executor_conf, cancel_token.clone());
+                let (sender, handle) = run_executor(
+                    checker.clone(),
+                    producer,
+                    executor_conf,
+                    cancel_token.clone(),
+                );
                 let dummy_worker = tokio::spawn(async {});
                 (sender, handle, dummy_worker)
             }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -136,8 +136,7 @@ impl Manager {
         };
 
         let cancel_token = CancellationToken::new();
-        let cancel_future = cancel_token.clone().cancelled_owned();
-
+        
         let (executor_sender, executor_join_handle, results_worker) = match &config.producer_mode {
             ProducerMode::Vector => {
                 let (results_producer, results_worker) = VectorResultsProducer::new(
@@ -149,7 +148,7 @@ impl Manager {
                 // XXX: Executor will shutdown once the sender goes out of scope. This will happen once all
                 // referneces of the Sender (executor_sender) are dropped.
                 let (sender, handle) =
-                    run_executor(checker.clone(), producer, executor_conf, cancel_future);
+                    run_executor(checker.clone(), producer, executor_conf, cancel_token.clone());
                 (sender, handle, results_worker)
             }
             ProducerMode::Kafka => {
@@ -166,7 +165,7 @@ impl Manager {
                 // XXX: Executor will shutdown once the sender goes out of scope. This will happen once all
                 // referneces of the Sender (executor_sender) are dropped.
                 let (sender, handle) =
-                    run_executor(checker.clone(), producer, executor_conf, cancel_future);
+                    run_executor(checker.clone(), producer, executor_conf, cancel_token.clone());
                 let dummy_worker = tokio::spawn(async {});
                 (sender, handle, dummy_worker)
             }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -135,6 +135,9 @@ impl Manager {
             record_task_metrics: config.record_task_metrics,
         };
 
+        let cancel_token = CancellationToken::new();
+        let cancel_future = cancel_token.clone().cancelled_owned();
+
         let (executor_sender, executor_join_handle, results_worker) = match &config.producer_mode {
             ProducerMode::Vector => {
                 let (results_producer, results_worker) = VectorResultsProducer::new(
@@ -145,7 +148,8 @@ impl Manager {
                 let producer = Arc::new(results_producer);
                 // XXX: Executor will shutdown once the sender goes out of scope. This will happen once all
                 // referneces of the Sender (executor_sender) are dropped.
-                let (sender, handle) = run_executor(checker.clone(), producer, executor_conf);
+                let (sender, handle) =
+                    run_executor(checker.clone(), producer, executor_conf, cancel_future);
                 (sender, handle, results_worker)
             }
             ProducerMode::Kafka => {
@@ -161,7 +165,8 @@ impl Manager {
                 ));
                 // XXX: Executor will shutdown once the sender goes out of scope. This will happen once all
                 // referneces of the Sender (executor_sender) are dropped.
-                let (sender, handle) = run_executor(checker.clone(), producer, executor_conf);
+                let (sender, handle) =
+                    run_executor(checker.clone(), producer, executor_conf, cancel_future);
                 let dummy_worker = tokio::spawn(async {});
                 (sender, handle, dummy_worker)
             }
@@ -174,7 +179,7 @@ impl Manager {
             services: RwLock::new(HashMap::new()),
             executor_sender,
             shutdown_sender,
-            shutdown_signal: CancellationToken::new(),
+            shutdown_signal: cancel_token,
         });
 
         let consumer_join_handle = match &manager.config.config_provider_mode {
@@ -206,10 +211,11 @@ impl Manager {
 
                 results_worker.await.expect("Failed to stop vector worker");
 
-                executor_join_handle.await.expect("Failed to stop executor");
                 services_join_handle
                     .await
                     .expect("Failed to stop partitioned services");
+
+                executor_join_handle.await.expect("Failed to stop executor");
             })
         }
     }


### PR DESCRIPTION
The executor will block indefinitely until all feeding producers are dropped.  We weren't shutting down the partitioned services when a shutdown was issued, but even with fixing that, the executor still holds on to a producer that it uses for its own retries.  So, just add a `take_until` on the stream, awaiting a future that is triggered by the cancel signal.