### PR TITLE
ref(uptime): rationalize usage of unwrap/expect; prefer Result<> to expect in some cases

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -157,7 +157,7 @@ impl Default for Config {
             log_format: logging::LogFormat::Auto,
             interface: None,
             metrics: MetricsConfig {
-                statsd_addr: "127.0.0.1:8126".parse().unwrap(),
+                statsd_addr: "127.0.0.1:8126".parse().expect("Parsable by construction"),
                 default_tags: BTreeMap::new(),
                 hostname_tag: None,
             },

--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -1,20 +1,16 @@
-use redis::AsyncCommands;
-use std::collections::HashSet;
-use std::sync::Arc;
-use tokio::task::JoinHandle;
-use tokio_util::sync::CancellationToken;
-
+use crate::redis::RedisClient;
 use crate::{app::config::Config, manager::Manager, types::check_config::CheckConfig};
-
-use chrono::Utc;
+use anyhow::Result;
+use redis::AsyncCommands;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 use tokio::time::interval;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
-
-#[allow(unused_imports)]
-use crate::redis::{RedisAsyncConnection, RedisClient};
 
 #[derive(Debug)]
 pub struct RedisPartition {
@@ -83,8 +79,8 @@ impl RedisConfigProvider {
         check_interval: Duration,
         enable_cluster: bool,
         redis_timeouts_ms: u64,
-    ) -> Result<Self, redis::RedisError> {
-        let client = crate::redis::build_redis_client(redis_url, enable_cluster);
+    ) -> Result<Self> {
+        let client = crate::redis::build_redis_client(redis_url, enable_cluster)?;
         Ok(Self {
             redis: client,
             partitions,
@@ -372,6 +368,8 @@ pub fn determine_owned_partitions(config: &Config) -> HashSet<u16> {
 
 #[cfg(test)]
 mod tests {
+    use crate::redis::RedisAsyncConnection;
+
     use super::*;
     use redis::AsyncCommands;
     use redis_test_macro::redis_test;

--- a/src/checker/ip_filter.rs
+++ b/src/checker/ip_filter.rs
@@ -52,7 +52,10 @@ pub static PRIVATE_RANGES: LazyLock<Vec<IpNet>> = LazyLock::new(|| {
         "ff00::/8",
     ];
 
-    addresses.iter().map(|addr| addr.parse().unwrap()).collect()
+    addresses
+        .iter()
+        .map(|addr| addr.parse().expect("Addresses parse by construction"))
+        .collect()
 });
 
 pub fn is_external_ip(ip: IpAddr) -> bool {

--- a/src/checker/isahc_checker.rs
+++ b/src/checker/isahc_checker.rs
@@ -119,7 +119,7 @@ impl Checker for IsahcChecker {
 
         let start = Instant::now();
         let response = do_request(&self.client, config, &trace_header).await;
-        let duration = Some(TimeDelta::from_std(start.elapsed()).unwrap());
+        let duration = Some(TimeDelta::from_std(start.elapsed()).expect("Duration should be sane"));
 
         let status = if response.as_ref().is_ok_and(|r| r.status().is_success()) {
             CheckStatus::Success

--- a/src/config_waiter.rs
+++ b/src/config_waiter.rs
@@ -53,7 +53,7 @@ pub fn wait_for_partition_boot(
 
             let last_update = config_store
                 .read()
-                .expect("Lock poisoned")
+                .expect("Lock should not be poisoned")
                 .get_last_update();
 
             // If it's been longer than the BOOT_MAX_IDLE and we haven't updated the config store
@@ -70,7 +70,7 @@ pub fn wait_for_partition_boot(
         let boot_time_ms = start.elapsed().as_millis();
         let total_configs = config_store
             .read()
-            .expect("Lock poisoned")
+            .expect("Lock should not be poisoned")
             .all_configs()
             .len();
 
@@ -87,7 +87,7 @@ pub fn wait_for_partition_boot(
         if shutdown.is_cancelled() {
             boot_finished
                 .send(BootResult::Cancelled)
-                .expect("Failed to report boot cancellation");
+                .expect("Receiver should still exist");
             return;
         }
 
@@ -105,7 +105,7 @@ pub fn wait_for_partition_boot(
 
         boot_finished
             .send(BootResult::Started)
-            .expect("Failed to report boot");
+            .expect("Receiver should still exist");
     });
 
     boot_finished_rx

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -80,7 +80,7 @@ impl LoggingConfig {
 
 pub fn init(config: LoggingConfig) {
     if let Some(dsn) = &config.sentry_dsn {
-        let dsn = Some(Dsn::from_str(dsn).expect("Invalid Sentry DSN"));
+        let dsn = Some(Dsn::from_str(dsn).expect("DSN should be valid"));
 
         let guard = sentry::init(sentry::ClientOptions {
             dsn,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -23,7 +23,7 @@ pub fn init(config: &MetricsConfig) {
 
     let recorder = builder
         .build(Some("uptime_checker"))
-        .expect("Could not create StatsdRecorder");
+        .expect("Builder should be valid");
 
-    metrics::set_global_recorder(recorder).expect("Could not set global metrics recorder")
+    metrics::set_global_recorder(recorder).expect("Global recorder should be settable")
 }

--- a/src/producer/dummy_producer.rs
+++ b/src/producer/dummy_producer.rs
@@ -8,7 +8,8 @@ pub struct DummyResultsProducer {
 
 impl DummyResultsProducer {
     pub fn new(topic_name: &str) -> Self {
-        let schema = sentry_kafka_schemas::get_schema(topic_name, None).unwrap();
+        let schema =
+            sentry_kafka_schemas::get_schema(topic_name, None).expect("Schema should exist");
         Self { schema }
     }
 }

--- a/src/producer/kafka_producer.rs
+++ b/src/producer/kafka_producer.rs
@@ -20,7 +20,8 @@ impl KafkaResultsProducer {
     pub fn new(topic_name: &str, config: KafkaConfig) -> Self {
         let producer = KafkaProducer::new(config);
         let topic = TopicOrPartition::Topic(Topic::new(topic_name));
-        let schema = sentry_kafka_schemas::get_schema("uptime-results", None).unwrap();
+        let schema =
+            sentry_kafka_schemas::get_schema("uptime-results", None).expect("Schema should exist");
 
         Self {
             producer,

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -16,7 +16,8 @@ impl VectorResultsProducer {
         endpoint: String,
         vector_batch_size: usize,
     ) -> (Self, JoinHandle<()>) {
-        let schema = sentry_kafka_schemas::get_schema(topic_name, None).unwrap();
+        let schema =
+            sentry_kafka_schemas::get_schema(topic_name, None).expect("Schema should exist");
         let client = Client::new();
 
         let (sender, receiver) = mpsc::unbounded_channel();

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use redis::aio::ConnectionLike;
 use redis::cluster::{ClusterClient, ClusterConfig};
 use redis::{Cmd, Pipeline, RedisError, RedisFuture, Value};
@@ -46,16 +47,14 @@ pub enum RedisClient {
     Single(redis::Client),
 }
 
-pub fn build_redis_client(redis_url: &str, enable_cluster: bool) -> RedisClient {
-    if enable_cluster {
-        RedisClient::Cluster(
-            ClusterClient::builder(vec![redis_url.to_string()])
-                .build()
-                .expect("Failed to build cluster client"),
-        )
+pub fn build_redis_client(redis_url: &str, enable_cluster: bool) -> Result<RedisClient> {
+    let client = if enable_cluster {
+        RedisClient::Cluster(ClusterClient::builder(vec![redis_url.to_string()]).build()?)
     } else {
-        RedisClient::Single(redis::Client::open(redis_url).expect("Failed to open redis client"))
-    }
+        RedisClient::Single(redis::Client::open(redis_url)?)
+    };
+
+    Ok(client)
 }
 
 impl RedisClient {

--- a/src/types/check_config.rs
+++ b/src/types/check_config.rs
@@ -101,7 +101,7 @@ impl CheckConfig {
         )
         .as_u128()
         .checked_rem(self.interval as u128)
-        .unwrap() as usize;
+        .expect("Interval cannot be zero") as usize;
 
         let pattern_count = MAX_CHECK_INTERVAL_SECS / interval_secs;
 
@@ -126,6 +126,11 @@ impl CheckConfig {
             return true;
         };
 
+        if active_regions.is_empty() {
+            // No active regions means we just run
+            return true;
+        }
+
         // We deterministically produce a new uuid here based on the subscription id and use it to
         // help distribute when we run each check in a region. Without this, we end up running all
         // checks for each region at the same time, and then idling.
@@ -140,7 +145,7 @@ impl CheckConfig {
         let running_region_idx = (((tick.time().timestamp() / self.interval as i64) as u128)
             + subscription_seed_id.as_u128())
         .checked_rem(active_regions.len() as u128)
-        .unwrap();
+        .expect("Active regions is non-zero");
         active_regions[running_region_idx as usize] == current_region
     }
 }


### PR DESCRIPTION
1. `expect` ought to be called with the reason we think the preceding call will not fail; update our usages accordingly
2. Prefer `expect` over `unwrap`, as the additional context/reasoning of `expect` is helpful
3. Remove some `expects` from lower-level code, replacing them with `Result<...>`s that propagates up the stack 
4. Replace some `expects` around things that shouldn't trigger complete failures with matching and tracing (in the scheduler tasks in particular)