### PR TITLE
ref(uptime): clean up unwrap/expect usage

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -157,7 +157,7 @@ impl Default for Config {
             log_format: logging::LogFormat::Auto,
             interface: None,
             metrics: MetricsConfig {
-                statsd_addr: "127.0.0.1:8126".parse().unwrap(),
+                statsd_addr: "127.0.0.1:8126".parse().expect("Parsable by construction"),
                 default_tags: BTreeMap::new(),
                 hostname_tag: None,
             },

--- a/src/checker/ip_filter.rs
+++ b/src/checker/ip_filter.rs
@@ -52,7 +52,10 @@ pub static PRIVATE_RANGES: LazyLock<Vec<IpNet>> = LazyLock::new(|| {
         "ff00::/8",
     ];
 
-    addresses.iter().map(|addr| addr.parse().unwrap()).collect()
+    addresses
+        .iter()
+        .map(|addr| addr.parse().expect("Addresses parse by construction"))
+        .collect()
 });
 
 pub fn is_external_ip(ip: IpAddr) -> bool {

--- a/src/checker/isahc_checker.rs
+++ b/src/checker/isahc_checker.rs
@@ -119,7 +119,7 @@ impl Checker for IsahcChecker {
 
         let start = Instant::now();
         let response = do_request(&self.client, config, &trace_header).await;
-        let duration = Some(TimeDelta::from_std(start.elapsed()).unwrap());
+        let duration = Some(TimeDelta::from_std(start.elapsed()).expect("Duration should be sane"));
 
         let status = if response.as_ref().is_ok_and(|r| r.status().is_success()) {
             CheckStatus::Success

--- a/src/checker/reqwest_checker.rs
+++ b/src/checker/reqwest_checker.rs
@@ -169,7 +169,13 @@ fn hyper_util_error(err: &reqwest::Error) -> Option<(CheckStatusReasonType, Stri
 impl ReqwestChecker {
     fn new_internal(options: Options) -> Self {
         let mut default_headers = HeaderMap::new();
-        default_headers.insert("User-Agent", UPTIME_USER_AGENT.to_string().parse().unwrap());
+        default_headers.insert(
+            "User-Agent",
+            UPTIME_USER_AGENT
+                .to_string()
+                .parse()
+                .expect("Valid by construction"),
+        );
 
         let mut builder = ClientBuilder::new()
             .hickory_dns(true)

--- a/src/config_waiter.rs
+++ b/src/config_waiter.rs
@@ -53,7 +53,7 @@ pub fn wait_for_partition_boot(
 
             let last_update = config_store
                 .read()
-                .expect("Lock poisoned")
+                .expect("Lock should not be poisoned")
                 .get_last_update();
 
             // If it's been longer than the BOOT_MAX_IDLE and we haven't updated the config store
@@ -70,7 +70,7 @@ pub fn wait_for_partition_boot(
         let boot_time_ms = start.elapsed().as_millis();
         let total_configs = config_store
             .read()
-            .expect("Lock poisoned")
+            .expect("Lock should not be poisoned")
             .all_configs()
             .len();
 
@@ -87,7 +87,7 @@ pub fn wait_for_partition_boot(
         if shutdown.is_cancelled() {
             boot_finished
                 .send(BootResult::Cancelled)
-                .expect("Failed to report boot cancellation");
+                .expect("Receiver should still exist");
             return;
         }
 
@@ -105,7 +105,7 @@ pub fn wait_for_partition_boot(
 
         boot_finished
             .send(BootResult::Started)
-            .expect("Failed to report boot");
+            .expect("Receiver should still exist");
     });
 
     boot_finished_rx

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -80,7 +80,7 @@ impl LoggingConfig {
 
 pub fn init(config: LoggingConfig) {
     if let Some(dsn) = &config.sentry_dsn {
-        let dsn = Some(Dsn::from_str(dsn).expect("Invalid Sentry DSN"));
+        let dsn = Some(Dsn::from_str(dsn).expect("DSN should be valid"));
 
         let guard = sentry::init(sentry::ClientOptions {
             dsn,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -23,7 +23,7 @@ pub fn init(config: &MetricsConfig) {
 
     let recorder = builder
         .build(Some("uptime_checker"))
-        .expect("Could not create StatsdRecorder");
+        .expect("Builder should be valid");
 
-    metrics::set_global_recorder(recorder).expect("Could not set global metrics recorder")
+    metrics::set_global_recorder(recorder).expect("Global recorder should be settable")
 }

--- a/src/producer/dummy_producer.rs
+++ b/src/producer/dummy_producer.rs
@@ -8,7 +8,8 @@ pub struct DummyResultsProducer {
 
 impl DummyResultsProducer {
     pub fn new(topic_name: &str) -> Self {
-        let schema = sentry_kafka_schemas::get_schema(topic_name, None).unwrap();
+        let schema =
+            sentry_kafka_schemas::get_schema(topic_name, None).expect("Schema should exist");
         Self { schema }
     }
 }

--- a/src/producer/kafka_producer.rs
+++ b/src/producer/kafka_producer.rs
@@ -20,7 +20,8 @@ impl KafkaResultsProducer {
     pub fn new(topic_name: &str, config: KafkaConfig) -> Self {
         let producer = KafkaProducer::new(config);
         let topic = TopicOrPartition::Topic(Topic::new(topic_name));
-        let schema = sentry_kafka_schemas::get_schema("uptime-results", None).unwrap();
+        let schema =
+            sentry_kafka_schemas::get_schema("uptime-results", None).expect("Schema should exist");
 
         Self {
             producer,

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -16,7 +16,8 @@ impl VectorResultsProducer {
         endpoint: String,
         vector_batch_size: usize,
     ) -> (Self, JoinHandle<()>) {
-        let schema = sentry_kafka_schemas::get_schema(topic_name, None).unwrap();
+        let schema =
+            sentry_kafka_schemas::get_schema(topic_name, None).expect("Schema should exist");
         let client = Client::new();
 
         let (sender, receiver) = mpsc::unbounded_channel();

--- a/src/types/check_config.rs
+++ b/src/types/check_config.rs
@@ -101,7 +101,7 @@ impl CheckConfig {
         )
         .as_u128()
         .checked_rem(self.interval as u128)
-        .unwrap() as usize;
+        .expect("Interval cannot be zero") as usize;
 
         let pattern_count = MAX_CHECK_INTERVAL_SECS / interval_secs;
 
@@ -140,7 +140,7 @@ impl CheckConfig {
         let running_region_idx = (((tick.time().timestamp() / self.interval as i64) as u128)
             + subscription_seed_id.as_u128())
         .checked_rem(active_regions.len() as u128)
-        .unwrap();
+        .expect("Active regions is non-zero");
         active_regions[running_region_idx as usize] == current_region
     }
 }


### PR DESCRIPTION
1. `expect` ought to be called with the reason we think the preceding call will not fail; update our usages accordingly
2. Prefer `expect` over `unwrap`, as the additional context/reasoning of `expect` is helpful