### PR TITLE
ref(uptime): use stdtime over chrono for interval timing

### DIFF
--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -315,13 +315,13 @@ fn record_result_metrics(result: &CheckResult, is_retry: bool, will_retry: bool)
             "is_retry" => retry_label,
             "will_retry" => will_retry_label,
         )
-        .record(duration.to_std().unwrap().as_secs_f64());
+        .record(duration.to_std().unwrap_or_default().as_secs_f64());
     }
 
     // Record time between scheduled and actual check
     let delay = (*actual_check_time - *scheduled_check_time)
         .to_std()
-        .unwrap()
+        .unwrap_or_default()
         .as_secs_f64();
 
     metrics::histogram!(

--- a/src/checker/isahc_checker.rs
+++ b/src/checker/isahc_checker.rs
@@ -54,7 +54,7 @@ async fn do_request(
     let timeout = check_config
         .timeout
         .to_std()
-        .expect("Timeout duration could not be converted to std::time::Duration");
+        .expect("Timeout duration should be representable as a duration");
 
     let url = check_config.url.as_str();
 

--- a/src/checker/reqwest_checker.rs
+++ b/src/checker/reqwest_checker.rs
@@ -62,7 +62,7 @@ async fn do_request(
     let timeout = check_config
         .timeout
         .to_std()
-        .expect("Timeout duration could not be converted to std::time::Duration");
+        .expect("Timeout duration should be representable as a duration");
 
     let url = check_config.url.as_str();
 
@@ -200,7 +200,7 @@ impl ReqwestChecker {
             builder = builder.interface(&nic);
         }
 
-        let client = builder.build().expect("Failed to build checker client");
+        let client = builder.build().expect("builder should be buildable");
 
         Self { client }
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -98,7 +98,7 @@ async fn scheduler_loop(
     tracing::info!(%start, "scheduler.starting_at");
 
     let start_at = Instant::now()
-        .checked_sub((Utc::now() - start).to_std().unwrap())
+        .checked_sub((Utc::now() - start).to_std().unwrap_or_default())
         .expect("Instant should be representable");
     let mut interval = interval(tick_frequency);
     interval.reset_at(start_at);


### PR DESCRIPTION
std::time::Instant::now() is guaranteed to be monotonic, whereas Utc::now() can time-travel a bit.

Also, when we must do `to_std` or `checked_sub` with Utc times, provide a default (0) if the subtraction fails due to the aforementioned time-travel.