### PR TITLE
ref(uptime): return Result<> structs and log/trace instead of panicking in the scheduler loop

### DIFF
--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -1,10 +1,13 @@
+use anyhow::Result;
 use redis::AsyncCommands;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use crate::{app::config::Config, manager::Manager, types::check_config::CheckConfig};
+use crate::{
+    app::config::Config, manager::Manager, redis::RedisClient, types::check_config::CheckConfig,
+};
 
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -12,9 +15,6 @@ use serde_with::serde_as;
 use std::time::Duration;
 use tokio::time::interval;
 use uuid::Uuid;
-
-#[allow(unused_imports)]
-use crate::redis::{RedisAsyncConnection, RedisClient};
 
 #[derive(Debug)]
 pub struct RedisPartition {
@@ -83,8 +83,8 @@ impl RedisConfigProvider {
         check_interval: Duration,
         enable_cluster: bool,
         redis_timeouts_ms: u64,
-    ) -> Result<Self, redis::RedisError> {
-        let client = crate::redis::build_redis_client(redis_url, enable_cluster);
+    ) -> Result<Self> {
+        let client = crate::redis::build_redis_client(redis_url, enable_cluster)?;
         Ok(Self {
             redis: client,
             partitions,
@@ -375,6 +375,8 @@ pub fn determine_owned_partitions(config: &Config) -> HashSet<u16> {
 
 #[cfg(test)]
 mod tests {
+    use crate::redis::RedisAsyncConnection;
+
     use super::*;
     use redis::AsyncCommands;
     use redis_test_macro::redis_test;

--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::Result;
 use chrono::{TimeDelta, Utc};
 use futures::StreamExt;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
@@ -41,10 +42,10 @@ impl ScheduledCheck {
     }
 
     /// Report the completion of the scheduled check.
-    pub fn record_result(self, result: CheckResult) {
+    pub fn record_result(self, result: CheckResult) -> Result<()> {
         self.resolve_tx
             .send(result)
-            .expect("Failed to resolve completed check");
+            .map_err(|_| anyhow::anyhow!("Scheduled check send error"))
     }
 }
 
@@ -71,7 +72,11 @@ impl CheckSender {
 
     /// Queues a check for execution, returning a oneshot receiver that will be fired once the check
     /// has resolved to a CheckResult.
-    pub fn queue_check(&self, tick: Tick, config: Arc<CheckConfig>) -> Receiver<CheckResult> {
+    pub fn queue_check(
+        &self,
+        tick: Tick,
+        config: Arc<CheckConfig>,
+    ) -> anyhow::Result<Receiver<CheckResult>> {
         let (resolve_tx, resolve_rx) = oneshot::channel();
 
         let scheduled_check = ScheduledCheck {
@@ -82,20 +87,19 @@ impl CheckSender {
         };
 
         self.queue_size.fetch_add(1, Ordering::SeqCst);
-        self.sender
-            .send(scheduled_check)
-            .expect("Failed to queue ScheduledCheck");
 
-        resolve_rx
+        // The SendError type from `send` doesn't have any useful context (except the entire
+        // check object!) so just map to empty.
+        self.sender.send(scheduled_check)?;
+        Ok(resolve_rx)
     }
 
     /// Requeues the check to be executed again, increasing the number of retries by 1
-    fn queue_check_for_retry(&self, mut check: ScheduledCheck) {
+    fn queue_check_for_retry(&self, mut check: ScheduledCheck) -> Result<()> {
         check.retry_count += 1;
         self.queue_size.fetch_add(1, Ordering::SeqCst);
-        self.sender
-            .send(check)
-            .expect("Failed to queue ScheduledCheck");
+        self.sender.send(check)?;
+        Ok(())
     }
 }
 
@@ -243,7 +247,11 @@ async fn executor_loop(
                     // re-queue for execution again
                     if will_retry {
                         tracing::debug!(result = ?check_result, "executor.check_will_retry");
-                        job_check_sender.queue_check_for_retry(scheduled_check);
+
+                        // Expect is necessary here--we need to break out of the stream processing loop.
+                        job_check_sender
+                            .queue_check_for_retry(scheduled_check)
+                            .expect("Executor loop channel should exist");
                         job_num_running.fetch_sub(1, Ordering::SeqCst);
                         return;
                     }
@@ -254,14 +262,20 @@ async fn executor_loop(
 
                     tracing::debug!(result = ?check_result, "executor.check_complete");
 
-                    scheduled_check.record_result(check_result);
+                    // Expect is necessary here--we need to break out of the stream processing loop.
+                    scheduled_check
+                        .record_result(check_result)
+                        .expect("Check recording channel should exist");
                     job_num_running.fetch_sub(1, Ordering::SeqCst);
                 };
 
                 if conf.record_task_metrics {
-                    let _ = job_metrics_monitor.instrument(check_task).await;
+                    job_metrics_monitor.instrument(check_task).await;
                 } else {
-                    let _ = tokio::spawn(check_task).await;
+                    // Expect is necessary here--we need to break out of the stream processing loop.
+                    tokio::spawn(check_task)
+                        .await
+                        .expect("The check task should not fail");
                 }
             }
         })
@@ -438,7 +452,7 @@ mod tests {
             ..Default::default()
         });
 
-        let resolve_rx = sender.queue_check(tick, config.clone());
+        let resolve_rx = sender.queue_check(tick, config.clone()).unwrap();
         tokio::pin!(resolve_rx);
 
         // Will not be resolved yet
@@ -483,7 +497,7 @@ mod tests {
                     subscription_id: Uuid::from_u128(i),
                     ..Default::default()
                 });
-                sender.queue_check(tick, config)
+                sender.queue_check(tick, config).unwrap()
             })
             .collect();
 
@@ -566,7 +580,11 @@ mod tests {
             ..Default::default()
         });
 
-        let result = sender.queue_check(tick, config.clone()).await.unwrap();
+        let result = sender
+            .queue_check(tick, config.clone())
+            .unwrap()
+            .await
+            .unwrap();
 
         assert_eq!(result.subscription_id, config.subscription_id);
         assert_eq!(result.status, CheckStatus::MissedWindow);
@@ -607,10 +625,9 @@ mod tests {
         });
 
         let resolve_rx = sender.queue_check(tick, config.clone());
-        tokio::pin!(resolve_rx);
 
         // Resolves as success since we will retry
-        let result = resolve_rx.await.unwrap();
+        let result = resolve_rx.unwrap().await.unwrap();
         assert_eq!(result.subscription_id, config.subscription_id);
         assert_eq!(result.status, CheckStatus::Success);
     }
@@ -653,10 +670,9 @@ mod tests {
         });
 
         let resolve_rx = sender.queue_check(tick, config.clone());
-        tokio::pin!(resolve_rx);
 
         // Resolves as failure after the two retries
-        let result = resolve_rx.await.unwrap();
+        let result = resolve_rx.unwrap().await.unwrap();
         assert_eq!(result.subscription_id, config.subscription_id);
         assert_eq!(result.status, CheckStatus::Failure);
     }

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use redis::aio::ConnectionLike;
 use redis::cluster::{ClusterClient, ClusterConfig};
 use redis::{Cmd, Pipeline, RedisError, RedisFuture, Value};
@@ -46,16 +47,14 @@ pub enum RedisClient {
     Single(redis::Client),
 }
 
-pub fn build_redis_client(redis_url: &str, enable_cluster: bool) -> RedisClient {
-    if enable_cluster {
-        RedisClient::Cluster(
-            ClusterClient::builder(vec![redis_url.to_string()])
-                .build()
-                .expect("Failed to build cluster client"),
-        )
+pub fn build_redis_client(redis_url: &str, enable_cluster: bool) -> Result<RedisClient> {
+    let client = if enable_cluster {
+        RedisClient::Cluster(ClusterClient::builder(vec![redis_url.to_string()]).build()?)
     } else {
-        RedisClient::Single(redis::Client::open(redis_url).expect("Failed to open redis client"))
-    }
+        RedisClient::Single(redis::Client::open(redis_url)?)
+    };
+
+    Ok(client)
 }
 
 impl RedisClient {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use chrono::{DurationRound, TimeDelta, TimeZone, Utc};
 use std::sync::Arc;
 
@@ -27,11 +28,13 @@ pub fn run_scheduler(
     region: String,
     redis_enable_cluster: bool,
     redis_timeouts_ms: u64,
+    tasks_finished_tx: mpsc::UnboundedSender<Result<(), anyhow::Error>>,
 ) -> JoinHandle<()> {
     tracing::info!(partition, "scheduler.starting");
     tokio::spawn(async move {
         let _ = config_loaded_receiver.await;
-        scheduler_loop(
+
+        let result = scheduler_loop(
             partition,
             config_store,
             executor_sender,
@@ -42,7 +45,11 @@ pub fn run_scheduler(
             redis_enable_cluster,
             redis_timeouts_ms,
         )
-        .await
+        .await;
+
+        // No need to check for an error--doesn't matter if this
+        // channel is open or not.
+        let _ = tasks_finished_tx.send(result);
     })
 }
 
@@ -57,16 +64,10 @@ async fn scheduler_loop(
     region: String,
     redis_enable_cluster: bool,
     redis_timeouts_ms: u64,
-) {
-    let client = build_redis_client(&redis_host, redis_enable_cluster);
-    let mut connection = client
-        .get_async_connection(redis_timeouts_ms)
-        .await
-        .expect("Unable to connect to redis");
-    let last_progress: Option<String> = connection
-        .get(&progress_key)
-        .await
-        .expect("Unable to get last tick key");
+) -> anyhow::Result<()> {
+    let client = build_redis_client(&redis_host, redis_enable_cluster)?;
+    let mut connection = client.get_async_connection(redis_timeouts_ms).await?;
+    let last_progress: Option<String> = connection.get(&progress_key).await?;
     let tick_frequency = Duration::from_secs(1);
     tracing::debug!(
         progress_key,
@@ -83,33 +84,27 @@ async fn scheduler_loop(
             // There's a race where a checker is running for a given progress_key, and another is starting.
             // Since we add `tick_frequency` to the date here, the date can end up in the future, which causes
             // a panic when we subtract it from `Utc::now()`. We avoid this by clamping to Utc::now().
-            next_check.min(
-                Utc::now()
-                    .duration_trunc(TimeDelta::seconds(1))
-                    .expect("Utc::now should be sane"),
-            )
+            next_check.min(Utc::now().duration_trunc(TimeDelta::seconds(1))?)
         }
         // We truncate the initial date to the nearest second so that we're aligned to the second
         // boundary here
-        None => Utc::now()
-            .duration_trunc(TimeDelta::seconds(1))
-            .expect("Utc::now should be sane"),
+        None => Utc::now().duration_trunc(TimeDelta::seconds(1))?,
     };
     tracing::info!(%start, "scheduler.starting_at");
 
     let start_at = Instant::now()
-        .checked_sub((Utc::now() - start).to_std().unwrap())
-        .expect("Instant should be representable");
+        .checked_sub((Utc::now() - start).to_std()?)
+        .unwrap_or(Instant::now());
     let mut interval = interval(tick_frequency);
     interval.reset_at(start_at);
 
     let (tick_complete_tx, mut tick_complete_rx) = mpsc::unbounded_channel();
 
-    let schedule_checks = |tick| {
+    let schedule_checks = |tick| -> anyhow::Result<()> {
         let tick_start = Instant::now();
         let configs = config_store
             .read()
-            .expect("Lock should not be poisoned")
+            .map_err(|_| anyhow::anyhow!("Lock poisoned"))?
             .get_configs(tick);
         let mut results = vec![];
         let mut bucket_size: usize = 0;
@@ -123,7 +118,10 @@ async fn scheduler_loop(
             )
             .increment(1);
             if config.should_run(tick, &region) {
-                results.push(executor_sender.queue_check(tick, config));
+                let check = executor_sender
+                    .queue_check(tick, config)
+                    .context("executor_sender.queue_check failed")?;
+                results.push(check);
                 bucket_size += 1;
             } else {
                 tracing::debug!(%config.subscription_id, %tick, "scheduler.skipped_config");
@@ -151,7 +149,12 @@ async fn scheduler_loop(
             let checks_scheduled = results.len();
             while let Some(result) = results.pop() {
                 // TODO(epurkhiser): Do we want to do something with the CheckResult here?
-                let _check_result = result.await.expect("Failed to receive CheckResult");
+                if let Err(err) = result.await {
+                    tracing::error!(error = ?err, "scheduler.tick_complete_join_await_error");
+                    return Err(anyhow::anyhow!(
+                        "Error receiving check result from executor"
+                    ));
+                }
             }
 
             let execution_duration = tick_start.elapsed();
@@ -162,12 +165,13 @@ async fn scheduler_loop(
                 checks_scheduled,
                 "scheduler.tick_execution_complete"
             );
-            tick
+            Ok(tick)
         });
 
         tick_complete_tx
             .send(tick_complete_join_handle)
-            .expect("Failed to queue join handle for tick completion");
+            .context("tick_complete_tx.send failure")?;
+        Ok(())
     };
 
     let in_order_tick_processor_join_handle = tokio::spawn(async move {
@@ -179,22 +183,32 @@ async fn scheduler_loop(
             .await
             > 0
         {
-            // XXX: This task guarantees that we can process ticks IN ORDER upon tick execution.
-            // This waits for the tick to complete before waiting on the next tick to complete.
+            // The handles arriving in the receiver are received in-order; look for the very
+            // latest tick that completed.
             tracing::debug!("scheduler.tick_awaiting_join_handle");
             let num_read = tick_handles.len();
 
-            // Only read the very last update's tick, since that will be the latest one we've successfully
-            // processed.
-            let tick = tick_handles.pop();
+            let Some(tick) = tick_handles.pop() else {
+                unreachable!("We have at least one element in the receive buffer");
+            };
+
+            let tick = match tick.await {
+                Ok(Ok(tick)) => tick,
+                Ok(Err(err)) => {
+                    tracing::error!(progress_key, error = ?err, "scheduler.tick_processor_handle_await_error");
+                    return Err(anyhow::anyhow!("other error"));
+                }
+                Err(err) => {
+                    tracing::error!(progress_key, error = ?err, "scheduler.tick_processor_handle_await_error");
+                    return Err(anyhow::anyhow!("join handle error"));
+                }
+            };
             tick_handles.clear();
 
-            let tick = tick
-                .unwrap()
-                .await
-                .expect("Failed to receive completed tick");
-
-            let progress = tick.time().timestamp_nanos_opt().unwrap();
+            let Some(progress) = tick.time().timestamp_nanos_opt() else {
+                tracing::error!(progress_key, tick = %tick, "scheduler.tick_processor_bad_timestamp");
+                continue;
+            };
             tracing::info!(tick = %tick, progress, num_read, "scheduler.tick_complete_join_handle");
 
             let result: Result<(), redis::RedisError> =
@@ -211,25 +225,32 @@ async fn scheduler_loop(
                     // Log and try reconnecting.
                     tracing::error!(progress_key, "scheduler.progress_saving_connection_dropped");
 
-                    connection = client
-                        .get_async_connection(redis_timeouts_ms)
-                        .await
-                        .expect("Unable to connect to redis");
+                    let new_connection = client.get_async_connection(redis_timeouts_ms).await;
+
+                    match new_connection {
+                        Ok(new_connection) => connection = new_connection,
+                        Err(err) => {
+                            tracing::error!(progress_key, error = %err, "scheduler.progress_saving_reconnect_failure");
+
+                            // Maybe it's coming back online--don't keep hammering something that isn't there.
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                        }
+                    }
                 } else {
                     tracing::error!(progress_key, error = %e, "scheduler.progress_fatal_error");
-
-                    panic!("Could not save scheduler progress: {:?}", e);
                 }
             }
             tracing::debug!(tick = %tick, "scheduler.tick_execution_complete_in_order");
         }
-        tracing::debug!("scheduler.tick_complete_join_handle_finished")
+        tracing::debug!("scheduler.tick_complete_join_handle_finished");
+
+        Ok(())
     });
 
     while !shutdown.is_cancelled() {
         let interval_tick = interval.tick().await;
         let tick = Tick::from_time(start + interval_tick.duration_since(start_at));
-        schedule_checks(tick);
+        schedule_checks(tick)?;
     }
     tracing::info!("scheduler.begin_shutdown");
 
@@ -237,6 +258,8 @@ async fn scheduler_loop(
     drop(tick_complete_tx);
     let _ = in_order_tick_processor_join_handle.await;
     tracing::info!("scheduler.shutdown");
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -251,7 +274,7 @@ mod tests {
     use socket_server_mocker::*;
     use std::ops::Add;
     use std::sync::Arc;
-    use tokio::sync::oneshot;
+    use tokio::sync::{mpsc, oneshot};
     use tokio_util::sync::CancellationToken;
     use tracing_test::traced_test;
     use uuid::Uuid;
@@ -302,6 +325,7 @@ mod tests {
         let (executor_tx, mut executor_rx) = CheckSender::new();
         let (boot_tx, boot_rx) = oneshot::channel::<BootResult>();
         let shutdown_token = CancellationToken::new();
+        let (shutdown_signal, _) = mpsc::unbounded_channel();
 
         let join_handle = run_scheduler(
             partition,
@@ -314,6 +338,7 @@ mod tests {
             config.region.clone(),
             false,
             0,
+            shutdown_signal,
         );
         let _ = boot_tx.send(BootResult::Started);
 
@@ -334,32 +359,36 @@ mod tests {
         );
 
         // Record results for both to complete both ticks
-        scheduled_check1.record_result(CheckResult {
-            guid: Uuid::new_v4(),
-            subscription_id: config1.subscription_id,
-            status: CheckStatus::Success,
-            status_reason: None,
-            trace_id: Default::default(),
-            span_id: Default::default(),
-            scheduled_check_time: scheduled_check1_time,
-            actual_check_time: Utc::now(),
-            duration: Some(Duration::seconds(1)),
-            request_info: None,
-            region: config.region.clone(),
-        });
-        scheduled_check2.record_result(CheckResult {
-            guid: Uuid::new_v4(),
-            subscription_id: config2.subscription_id,
-            status: CheckStatus::Success,
-            status_reason: None,
-            trace_id: Default::default(),
-            span_id: Default::default(),
-            scheduled_check_time: scheduled_check2_time,
-            actual_check_time: Utc::now(),
-            duration: Some(Duration::seconds(1)),
-            request_info: None,
-            region: config.region.clone(),
-        });
+        scheduled_check1
+            .record_result(CheckResult {
+                guid: Uuid::new_v4(),
+                subscription_id: config1.subscription_id,
+                status: CheckStatus::Success,
+                status_reason: None,
+                trace_id: Default::default(),
+                span_id: Default::default(),
+                scheduled_check_time: scheduled_check1_time,
+                actual_check_time: Utc::now(),
+                duration: Some(Duration::seconds(1)),
+                request_info: None,
+                region: config.region.clone(),
+            })
+            .unwrap();
+        scheduled_check2
+            .record_result(CheckResult {
+                guid: Uuid::new_v4(),
+                subscription_id: config2.subscription_id,
+                status: CheckStatus::Success,
+                status_reason: None,
+                trace_id: Default::default(),
+                span_id: Default::default(),
+                scheduled_check_time: scheduled_check2_time,
+                actual_check_time: Utc::now(),
+                duration: Some(Duration::seconds(1)),
+                request_info: None,
+                region: config.region.clone(),
+            })
+            .unwrap();
 
         shutdown_token.cancel();
         join_handle.await.unwrap();
@@ -419,6 +448,7 @@ mod tests {
         let (executor_tx, mut executor_rx) = CheckSender::new();
         let (boot_tx, boot_rx) = oneshot::channel::<BootResult>();
         let shutdown_token = CancellationToken::new();
+        let (shutdown_signal, _) = mpsc::unbounded_channel();
 
         let join_handle = run_scheduler(
             partition,
@@ -431,6 +461,7 @@ mod tests {
             config.region.clone(),
             false,
             100,
+            shutdown_signal,
         );
         let _ = boot_tx.send(BootResult::Started);
 
@@ -440,19 +471,21 @@ mod tests {
         assert_eq!(scheduled_check1.get_config().clone(), config1);
 
         // Record results for both to complete both ticks
-        scheduled_check1.record_result(CheckResult {
-            guid: Uuid::new_v4(),
-            subscription_id: config1.subscription_id,
-            status: CheckStatus::Success,
-            status_reason: None,
-            trace_id: Default::default(),
-            span_id: Default::default(),
-            scheduled_check_time: scheduled_check1_time,
-            actual_check_time: Utc::now(),
-            duration: Some(Duration::seconds(1)),
-            request_info: None,
-            region: config.region.clone(),
-        });
+        scheduled_check1
+            .record_result(CheckResult {
+                guid: Uuid::new_v4(),
+                subscription_id: config1.subscription_id,
+                status: CheckStatus::Success,
+                status_reason: None,
+                trace_id: Default::default(),
+                span_id: Default::default(),
+                scheduled_check_time: scheduled_check1_time,
+                actual_check_time: Utc::now(),
+                duration: Some(Duration::seconds(1)),
+                request_info: None,
+                region: config.region.clone(),
+            })
+            .unwrap();
 
         shutdown_token.cancel();
         join_handle.await.unwrap();
@@ -506,6 +539,7 @@ mod tests {
         let (executor_tx, mut executor_rx) = CheckSender::new();
         let (boot_tx, boot_rx) = oneshot::channel::<BootResult>();
         let shutdown_token = CancellationToken::new();
+        let (shutdown_signal, _) = mpsc::unbounded_channel();
 
         let join_handle = run_scheduler(
             partition,
@@ -518,6 +552,7 @@ mod tests {
             config.region.clone(),
             false,
             0,
+            shutdown_signal,
         );
         let _ = boot_tx.send(BootResult::Started);
 
@@ -538,32 +573,36 @@ mod tests {
         );
 
         // Record results for both to complete both ticks
-        scheduled_check1.record_result(CheckResult {
-            guid: Uuid::new_v4(),
-            subscription_id: config1.subscription_id,
-            status: CheckStatus::Success,
-            status_reason: None,
-            trace_id: Default::default(),
-            span_id: Default::default(),
-            scheduled_check_time: scheduled_check1_time,
-            actual_check_time: Utc::now(),
-            duration: Some(Duration::seconds(1)),
-            request_info: None,
-            region: config.region.clone(),
-        });
-        scheduled_check2.record_result(CheckResult {
-            guid: Uuid::new_v4(),
-            subscription_id: config2.subscription_id,
-            status: CheckStatus::Success,
-            status_reason: None,
-            trace_id: Default::default(),
-            span_id: Default::default(),
-            scheduled_check_time: scheduled_check2_time,
-            actual_check_time: Utc::now(),
-            duration: Some(Duration::seconds(1)),
-            request_info: None,
-            region: config.region.clone(),
-        });
+        scheduled_check1
+            .record_result(CheckResult {
+                guid: Uuid::new_v4(),
+                subscription_id: config1.subscription_id,
+                status: CheckStatus::Success,
+                status_reason: None,
+                trace_id: Default::default(),
+                span_id: Default::default(),
+                scheduled_check_time: scheduled_check1_time,
+                actual_check_time: Utc::now(),
+                duration: Some(Duration::seconds(1)),
+                request_info: None,
+                region: config.region.clone(),
+            })
+            .unwrap();
+        scheduled_check2
+            .record_result(CheckResult {
+                guid: Uuid::new_v4(),
+                subscription_id: config2.subscription_id,
+                status: CheckStatus::Success,
+                status_reason: None,
+                trace_id: Default::default(),
+                span_id: Default::default(),
+                scheduled_check_time: scheduled_check2_time,
+                actual_check_time: Utc::now(),
+                duration: Some(Duration::seconds(1)),
+                request_info: None,
+                region: config.region.clone(),
+            })
+            .unwrap();
 
         shutdown_token.cancel();
         join_handle.await.unwrap();
@@ -611,6 +650,7 @@ mod tests {
         let (executor_tx, mut executor_rx) = CheckSender::new();
         let (boot_tx, boot_rx) = oneshot::channel::<BootResult>();
         let shutdown_token = CancellationToken::new();
+        let (shutdown_signal, _) = mpsc::unbounded_channel();
 
         let join_handle = run_scheduler(
             partition,
@@ -623,6 +663,7 @@ mod tests {
             config.region.clone(),
             false,
             0,
+            shutdown_signal,
         );
 
         let _ = boot_tx.send(BootResult::Started);
@@ -644,32 +685,36 @@ mod tests {
         );
 
         // Record results for both to complete both ticks
-        scheduled_check1.record_result(CheckResult {
-            guid: Uuid::new_v4(),
-            subscription_id: config2.subscription_id,
-            status: CheckStatus::Success,
-            status_reason: None,
-            trace_id: Default::default(),
-            span_id: Default::default(),
-            scheduled_check_time: scheduled_check1_time,
-            actual_check_time: Utc::now(),
-            duration: Some(Duration::seconds(1)),
-            request_info: None,
-            region: config.region.clone(),
-        });
-        scheduled_check2.record_result(CheckResult {
-            guid: Uuid::new_v4(),
-            subscription_id: config1.subscription_id,
-            status: CheckStatus::Success,
-            status_reason: None,
-            trace_id: Default::default(),
-            span_id: Default::default(),
-            scheduled_check_time: scheduled_check2_time,
-            actual_check_time: Utc::now(),
-            duration: Some(Duration::seconds(1)),
-            request_info: None,
-            region: config.region.clone(),
-        });
+        scheduled_check1
+            .record_result(CheckResult {
+                guid: Uuid::new_v4(),
+                subscription_id: config2.subscription_id,
+                status: CheckStatus::Success,
+                status_reason: None,
+                trace_id: Default::default(),
+                span_id: Default::default(),
+                scheduled_check_time: scheduled_check1_time,
+                actual_check_time: Utc::now(),
+                duration: Some(Duration::seconds(1)),
+                request_info: None,
+                region: config.region.clone(),
+            })
+            .unwrap();
+        scheduled_check2
+            .record_result(CheckResult {
+                guid: Uuid::new_v4(),
+                subscription_id: config1.subscription_id,
+                status: CheckStatus::Success,
+                status_reason: None,
+                trace_id: Default::default(),
+                span_id: Default::default(),
+                scheduled_check_time: scheduled_check2_time,
+                actual_check_time: Utc::now(),
+                duration: Some(Duration::seconds(1)),
+                request_info: None,
+                region: config.region.clone(),
+            })
+            .unwrap();
 
         shutdown_token.cancel();
         join_handle.await.unwrap();
@@ -714,6 +759,7 @@ mod tests {
         let (executor_tx, mut executor_rx) = CheckSender::new();
         let (boot_tx, boot_rx) = oneshot::channel::<BootResult>();
         let shutdown_token = CancellationToken::new();
+        let (shutdown_signal, _) = mpsc::unbounded_channel();
 
         let join_handle = run_scheduler(
             partition,
@@ -726,6 +772,7 @@ mod tests {
             config.region.clone(),
             false,
             0,
+            shutdown_signal,
         );
 
         let _ = boot_tx.send(BootResult::Started);
@@ -736,19 +783,21 @@ mod tests {
         assert_eq!(scheduled_check1.get_config().clone(), config1);
 
         // Record results for both to complete both ticks
-        scheduled_check1.record_result(CheckResult {
-            guid: Uuid::new_v4(),
-            subscription_id: config1.subscription_id,
-            status: CheckStatus::Success,
-            status_reason: None,
-            trace_id: Default::default(),
-            span_id: Default::default(),
-            scheduled_check_time: scheduled_check1_time,
-            actual_check_time: Utc::now(),
-            duration: Some(Duration::seconds(1)),
-            request_info: None,
-            region: config.region.clone(),
-        });
+        scheduled_check1
+            .record_result(CheckResult {
+                guid: Uuid::new_v4(),
+                subscription_id: config1.subscription_id,
+                status: CheckStatus::Success,
+                status_reason: None,
+                trace_id: Default::default(),
+                span_id: Default::default(),
+                scheduled_check_time: scheduled_check1_time,
+                actual_check_time: Utc::now(),
+                duration: Some(Duration::seconds(1)),
+                request_info: None,
+                region: config.region.clone(),
+            })
+            .unwrap();
 
         shutdown_token.cancel();
         join_handle.await.unwrap();


### PR DESCRIPTION
Part 1: scheduler loop.  I think this is the sane pattern we can repeat in our code for our other tasks: no more panicking, return errors, and the top-level function that is launched inside a tokio::spawn gets access to the common `tasks_finished` channel that will receive the return result from that function.  That in turn goes to the receiver in the app, which can then make a decision about what (if anything) to do with the result.  In this PR, if there's any kind of error, we'll just panic and die, but in the future we could put in some selective retries.

This does not address all the looping tasks we have; we still have the redis writer and the executor.  Those can be dealt with in forthcoming PRs.  If a panic does occur in any of those tasks, the resulting channels they use to communicate with are closed, and subsequent reads/writes to them generate errors in the scheduler, which lead to the entire service being brought down--it's just very circuitous and requires judicious log tracing to understand why.