### PR TITLE
ref(uptime): factor check_executor_loop

### DIFF
--- a/src/check_executor.rs
+++ b/src/check_executor.rs
@@ -224,79 +224,86 @@ async fn executor_loop(
             let job_region = conf.region.clone();
             let job_num_running = num_running.clone();
             let job_check_sender = check_sender.clone();
+            let job_queue_size = queue_size.clone();
 
-            let job_metrics_monitor = metrics_monitor.clone();
+            let check_fut = do_check(
+                &conf,
+                scheduled_check,
+                job_queue_size,
+                job_num_running,
+                job_checker,
+                job_check_sender,
+                job_producer,
+                job_region,
+            );
 
-            let num_running_val = num_running.fetch_add(1, Ordering::Relaxed);
-            let queue_size_val = queue_size.fetch_sub(1, Ordering::Relaxed);
-
-            metrics::gauge!("executor.queue_size", "uptime_region" => conf.region.clone())
-                .set(queue_size_val as f64);
-            metrics::gauge!("executor.num_running", "uptime_region" => conf.region.clone())
-                .set(num_running_val as f64);
-
-            async move {
-                let check_task = async move {
-                    let config = &scheduled_check.config;
-                    let tick = &scheduled_check.tick;
-
-                    // If a check execution is processed after more than the interval of the check
-                    // config we skip the check, we were too late
-                    let late_by = Utc::now() - tick.time();
-                    let interval = TimeDelta::seconds(config.interval as i64);
-
-                    let check_result = if late_by > interval {
-                        CheckResult::missed_from(&scheduled_check, job_region)
-                    } else {
-                        job_checker.check_url(&scheduled_check, job_region).await
-                    };
-
-                    let will_retry = check_result.status == CheckStatus::Failure
-                        && scheduled_check.retry_count < conf.failure_retries;
-
-                    record_result_metrics(
-                        &check_result,
-                        scheduled_check.retry_count > 0,
-                        will_retry,
-                    );
-
-                    // re-queue for execution again
-                    if will_retry {
-                        tracing::debug!(result = ?check_result, "executor.check_will_retry");
-
-                        // Expect is necessary here--we need to break out of the stream processing loop.
-                        job_check_sender
-                            .queue_check_for_retry(scheduled_check)
-                            .expect("Executor loop channel should exist");
-                        job_num_running.fetch_sub(1, Ordering::Relaxed);
-                        return;
-                    }
-
-                    if let Err(e) = job_producer.produce_checker_result(&check_result) {
-                        tracing::error!(error = ?e, "executor.failed_to_produce");
-                    }
-
-                    tracing::debug!(result = ?check_result, "executor.check_complete");
-
-                    // Expect is necessary here--we need to break out of the stream processing loop.
-                    scheduled_check
-                        .record_result(check_result)
-                        .expect("Check recording channel should exist");
-                    job_num_running.fetch_sub(1, Ordering::Relaxed);
-                };
-
-                if conf.record_task_metrics {
-                    job_metrics_monitor.instrument(check_task).await;
-                } else {
-                    // Expect is necessary here--we need to break out of the stream processing loop.
-                    tokio::spawn(check_task)
-                        .await
-                        .expect("The check task should not fail");
-                }
-            }
+            metrics_monitor.instrument(check_fut)
         })
         .await;
     tracing::info!("executor.shutdown");
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn do_check(
+    conf: &ExecutorConfig,
+    scheduled_check: ScheduledCheck,
+    queue_size: Arc<AtomicU64>,
+    num_running: Arc<AtomicU64>,
+    job_checker: Arc<impl Checker + 'static>,
+    job_check_sender: Arc<CheckSender>,
+    job_producer: Arc<impl ResultsProducer + 'static>,
+    job_region: String,
+) {
+    let num_running_val = num_running.fetch_add(1, Ordering::Relaxed);
+    let queue_size_val = queue_size.fetch_sub(1, Ordering::Relaxed);
+
+    metrics::gauge!("executor.queue_size", "uptime_region" => conf.region.clone())
+        .set(queue_size_val as f64);
+    metrics::gauge!("executor.num_running", "uptime_region" => conf.region.clone())
+        .set(num_running_val as f64);
+
+    let config = &scheduled_check.config;
+    let tick = &scheduled_check.tick;
+
+    // If a check execution is processed after more than the interval of the check
+    // config we skip the check, we were too late
+    let late_by = Utc::now() - tick.time();
+    let interval = TimeDelta::seconds(config.interval as i64);
+
+    let check_result = if late_by > interval {
+        CheckResult::missed_from(&scheduled_check, job_region)
+    } else {
+        job_checker.check_url(&scheduled_check, job_region).await
+    };
+
+    let will_retry = check_result.status == CheckStatus::Failure
+        && scheduled_check.retry_count < conf.failure_retries;
+
+    record_result_metrics(&check_result, scheduled_check.retry_count > 0, will_retry);
+
+    // re-queue for execution again
+    if will_retry {
+        tracing::debug!(result = ?check_result, "executor.check_will_retry");
+
+        // Expect is necessary here--we need to break out of the stream processing loop.
+        job_check_sender
+            .queue_check_for_retry(scheduled_check)
+            .expect("Executor loop channel should exist");
+        num_running.fetch_sub(1, Ordering::Relaxed);
+        return;
+    }
+
+    if let Err(e) = job_producer.produce_checker_result(&check_result) {
+        tracing::error!(error = ?e, "executor.failed_to_produce");
+    }
+
+    tracing::debug!(result = ?check_result, "executor.check_complete");
+
+    // Expect is necessary here--we need to break out of the stream processing loop.
+    scheduled_check
+        .record_result(check_result)
+        .expect("Check recording channel should exist");
+    num_running.fetch_sub(1, Ordering::Relaxed);
 }
 
 fn record_result_metrics(result: &CheckResult, is_retry: bool, will_retry: bool) {


### PR DESCRIPTION
In preparation for more changes; plus, it's a little easier to reason about.  Also, always instrument the resulting future.  (This is actually vital, as we otherwise start running into awful type problems with differently-typed futures being returned from the, but also, it's what we run in prod.)