### PR TITLE
ref(uptime): leak region string to avoid many allocations

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -50,7 +50,7 @@ pub trait Checker: Send + Sync {
     fn check_url(
         &self,
         check: &ScheduledCheck,
-        region: String,
+        region: &'static str,
     ) -> impl Future<Output = CheckResult> + Send;
 }
 
@@ -61,7 +61,7 @@ pub enum HttpChecker {
 }
 
 impl Checker for HttpChecker {
-    async fn check_url(&self, check: &ScheduledCheck, region: String) -> CheckResult {
+    async fn check_url(&self, check: &ScheduledCheck, region: &'static str) -> CheckResult {
         match self {
             Self::IsahcChecker(c) => c.check_url(check, region).await,
             Self::ReqwestChecker(c) => c.check_url(check, region).await,

--- a/src/checker/dummy_checker.rs
+++ b/src/checker/dummy_checker.rs
@@ -51,7 +51,7 @@ impl DummyChecker {
 }
 
 impl Checker for DummyChecker {
-    async fn check_url(&self, check: &ScheduledCheck, region: String) -> CheckResult {
+    async fn check_url(&self, check: &ScheduledCheck, region: &'static str) -> CheckResult {
         let scheduled_check_time = check.get_tick().time();
         let actual_check_time = Utc::now();
         let trace_id = Uuid::new_v4();

--- a/src/checker/isahc_checker.rs
+++ b/src/checker/isahc_checker.rs
@@ -110,7 +110,7 @@ impl Checker for IsahcChecker {
     /// Makes a request to a url to determine whether it is up.
     /// Up is defined as returning a 2xx within a specific timeframe.
     #[tracing::instrument]
-    async fn check_url(&self, check: &ScheduledCheck, region: String) -> CheckResult {
+    async fn check_url(&self, check: &ScheduledCheck, region: &'static str) -> CheckResult {
         let scheduled_check_time = check.get_tick().time();
         let actual_check_time = Utc::now();
         let span_id = SpanId::default();
@@ -253,7 +253,7 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Success);
         assert_eq!(
@@ -297,7 +297,7 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Success);
         assert_eq!(
@@ -336,7 +336,7 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Failure);
         assert!(result.duration.is_some_and(|d| d > timeout));
@@ -376,7 +376,7 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Failure);
         assert_eq!(
@@ -495,8 +495,8 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
-        let result_2 = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
+        let result_2 = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Success);
         assert_eq!(result_2.status, CheckStatus::Success);
@@ -630,7 +630,7 @@ mod tests {
             };
 
             let check = ScheduledCheck::new_for_test(tick, config);
-            let result = checker.check_url(&check, "us-west".into()).await;
+            let result = checker.check_url(&check, "us-west").await;
 
             assert_eq!(
                 result.status,
@@ -672,7 +672,7 @@ mod tests {
             ..Default::default()
         };
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
         assert_eq!(result.status, CheckStatus::Failure);
         assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
         assert_eq!(
@@ -710,7 +710,7 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
         assert_eq!(result.status, CheckStatus::Failure);
         assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
         assert_eq!(
@@ -754,7 +754,7 @@ mod tests {
             ..Default::default()
         };
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Failure);
         assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);

--- a/src/checker/reqwest_checker.rs
+++ b/src/checker/reqwest_checker.rs
@@ -226,7 +226,7 @@ impl Checker for ReqwestChecker {
     /// Makes a request to a url to determine whether it is up.
     /// Up is defined as returning a 2xx within a specific timeframe.
     #[tracing::instrument]
-    async fn check_url(&self, check: &ScheduledCheck, region: String) -> CheckResult {
+    async fn check_url(&self, check: &ScheduledCheck, region: &'static str) -> CheckResult {
         let scheduled_check_time = check.get_tick().time();
         let actual_check_time = Utc::now();
         let span_id = SpanId::default();
@@ -384,7 +384,7 @@ mod tests {
         let tick = make_tick();
 
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Success);
         assert_eq!(
@@ -430,7 +430,7 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Success);
         assert_eq!(
@@ -471,7 +471,7 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Failure);
         assert!(result.duration.is_some_and(|d| d > timeout));
@@ -513,7 +513,7 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Failure);
         assert_eq!(
@@ -549,7 +549,7 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, localhost_config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Failure);
         assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
@@ -581,7 +581,7 @@ mod tests {
         };
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, restricted_ip_config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Failure);
         assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
@@ -602,7 +602,7 @@ mod tests {
         };
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, restricted_ipv6_config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(
             result.status_reason.map(|r| r.description),
@@ -636,8 +636,8 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
-        let result_2 = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
+        let result_2 = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Success);
         assert_eq!(result_2.status, CheckStatus::Success);
@@ -763,7 +763,7 @@ mod tests {
                 ..Default::default()
             };
             let check = ScheduledCheck::new_for_test(tick, config);
-            let result = checker.check_url(&check, "us-west".into()).await;
+            let result = checker.check_url(&check, "us-west").await;
 
             assert_eq!(
                 result.status,
@@ -807,7 +807,7 @@ mod tests {
             ..Default::default()
         };
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
         assert_eq!(result.status, CheckStatus::Failure);
         assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
         assert_eq!(
@@ -847,7 +847,7 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Failure);
         assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
@@ -894,7 +894,7 @@ mod tests {
             ..Default::default()
         };
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Failure);
         assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
@@ -935,7 +935,7 @@ mod tests {
 
         let tick = make_tick();
         let check = ScheduledCheck::new_for_test(tick, config);
-        let result = checker.check_url(&check, "us-west".into()).await;
+        let result = checker.check_url(&check, "us-west").await;
 
         assert_eq!(result.status, CheckStatus::Success);
         assert_eq!(

--- a/src/config_waiter.rs
+++ b/src/config_waiter.rs
@@ -39,7 +39,7 @@ pub fn wait_for_partition_boot(
     config_store: Arc<RwConfigStore>,
     partition: u16,
     shutdown: CancellationToken,
-    region: String,
+    region: &'static str,
 ) -> Receiver<BootResult> {
     let start = Instant::now();
     let (boot_finished, boot_finished_rx) = oneshot::channel::<BootResult>();
@@ -126,12 +126,8 @@ mod tests {
         let config_store = Arc::new(ConfigStore::new_rw());
 
         let shutdown_signal = CancellationToken::new();
-        let wait_booted = wait_for_partition_boot(
-            config_store.clone(),
-            0,
-            shutdown_signal.clone(),
-            "us-west".to_string(),
-        );
+        let wait_booted =
+            wait_for_partition_boot(config_store.clone(), 0, shutdown_signal.clone(), "us-west");
         tokio::pin!(wait_booted);
 
         // nothing produced yet. Move time right before to the BOOT_MAX_IDLE.
@@ -172,12 +168,8 @@ mod tests {
         let config_store = Arc::new(ConfigStore::new_rw());
 
         let shutdown_signal = CancellationToken::new();
-        let wait_booted = wait_for_partition_boot(
-            config_store.clone(),
-            0,
-            shutdown_signal.clone(),
-            "us-west".to_string(),
-        );
+        let wait_booted =
+            wait_for_partition_boot(config_store.clone(), 0, shutdown_signal.clone(), "us-west");
         tokio::pin!(wait_booted);
 
         // nothing produced yet. Move time right before to the BOOT_MAX_IDLE.

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -59,7 +59,7 @@ impl PartitionedService {
             waiter_config_store,
             partition,
             shutdown_signal.clone(),
-            config.region.clone(),
+            config.region,
         );
 
         let scheduler_join_handle = run_scheduler(
@@ -70,7 +70,7 @@ impl PartitionedService {
             build_progress_key(partition),
             config.redis_host.clone(),
             config_loaded,
-            config.region.clone(),
+            config.region,
             config.redis_enable_cluster,
             config.redis_timeouts_ms,
             tasks_finished_tx,
@@ -167,7 +167,7 @@ impl Manager {
         let executor_conf = ExecutorConfig {
             concurrency: config.checker_concurrency,
             failure_retries: config.failure_retries,
-            region: config.region.clone(),
+            region: config.region,
             record_task_metrics: config.record_task_metrics,
         };
 

--- a/src/producer/kafka_producer.rs
+++ b/src/producer/kafka_producer.rs
@@ -85,7 +85,7 @@ mod tests {
                 request_type: RequestMethod::Get,
                 http_status_code: Some(200),
             }),
-            region: "us-west-1".to_string(),
+            region: "us-west-1",
         };
         // TODO: Have an actual Kafka running for a real test. At the moment this is fine since
         // it will fail async

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -148,7 +148,7 @@ mod tests {
                 request_type: RequestMethod::Get,
                 http_status_code: Some(200),
             }),
-            region: "us-west-1".to_string(),
+            region: "us-west-1",
         }
     }
 

--- a/src/types/result.rs
+++ b/src/types/result.rs
@@ -102,7 +102,7 @@ pub struct CheckResult {
     pub request_info: Option<RequestInfo>,
 
     /// Region slug that produced the check result
-    pub region: String,
+    pub region: &'static str,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
At the cost of some unfreeable memory (which won't be freed until the program shuts down, anyway) we avoid making string clones/heap allocations, especially in the inner scheduler and executor loops.