### PR TITLE
cloudbuild: use standardized build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80-alpine3.20 as builder
+FROM rust:1.80-alpine3.20 AS builder
 
 # Install system dependencies
 RUN apk add --no-cache \
@@ -42,11 +42,13 @@ RUN cargo build --release
 
 FROM alpine:3.20
 
-COPY --from=builder /app/target/release/uptime-checker /usr/local/bin/uptime-checker
+LABEL org.opencontainers.image.source="https://github.com/getsentry/uptime-checker"
 
 RUN apk add --no-cache tini libgcc curl && \
     addgroup -S app --gid 1000 && \
     adduser -S app -G app --uid 1000
+
+COPY --from=builder /app/target/release/uptime-checker /usr/local/bin/uptime-checker
 
 USER app
 

--- a/cloudbuild.ci.yaml
+++ b/cloudbuild.ci.yaml
@@ -27,4 +27,4 @@ steps:
 
 options:
   machineType: 'E2_HIGHCPU_32'
-  diskSizeGb: 100
+  diskSizeGb: 25

--- a/cloudbuild.ci.yaml
+++ b/cloudbuild.ci.yaml
@@ -1,0 +1,30 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'create-builder'
+    waitFor: ['-']
+    args: ['buildx', 'create', '--driver', 'docker-container', '--name', 'container', '--use']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-image'
+    waitFor: ['create-builder']
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -euxo pipefail
+        docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --cache-from $LOCATION-docker.pkg.dev/$PROJECT_ID/uptime-checker/image:latest \
+            -t $LOCATION-docker.pkg.dev/$PROJECT_ID/uptime-checker/image:$COMMIT_SHA \
+            --label org.opencontainers.image.revision=$COMMIT_SHA \
+            --label org.opencontainers.image.version=$COMMIT_SHA \
+            --label org.opencontainers.image.title=$REPO_NAME \
+            --label org.opencontainers.vendor="Sentry" \
+            --label org.opencontainers.image.source=https://github.com/$REPO_FULL_NAME \
+            --label org.opencontainers.image.url=https://github.com/$REPO_FULL_NAME \
+            --build-arg UPTIME_CHECKER_GIT_REVISION=$COMMIT_SHA \
+            .
+
+options:
+  machineType: 'E2_HIGHCPU_32'
+  diskSizeGb: 100

--- a/cloudbuild.ci.yaml
+++ b/cloudbuild.ci.yaml
@@ -1,15 +1,24 @@
 steps:
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'create-builder'
-    waitFor: ['-']
-    args: ['buildx', 'create', '--driver', 'docker-container', '--name', 'container', '--use']
-
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'build-image'
-    waitFor: ['create-builder']
-    entrypoint: 'bash'
+  - name: "gcr.io/cloud-builders/docker"
+    id: "create-builder"
+    waitFor: ["-"]
     args:
-      - '-c'
+      [
+        "buildx",
+        "create",
+        "--driver",
+        "docker-container",
+        "--name",
+        "container",
+        "--use",
+      ]
+
+  - name: "gcr.io/cloud-builders/docker"
+    id: "build-image"
+    waitFor: ["create-builder"]
+    entrypoint: "bash"
+    args:
+      - "-c"
       - |
         set -euxo pipefail
         docker buildx build \
@@ -25,6 +34,7 @@ steps:
             --build-arg UPTIME_CHECKER_GIT_REVISION=$COMMIT_SHA \
             .
 
+logsBucket: "gs://sentryio-cloudbuild-logs"
 options:
-  machineType: 'E2_HIGHCPU_32'
+  machineType: "E2_HIGHCPU_32"
   diskSizeGb: 25

--- a/cloudbuild.release.yaml
+++ b/cloudbuild.release.yaml
@@ -38,17 +38,14 @@ steps:
         docker buildx build \
             --push \
             --platform linux/amd64,linux/arm64 \
-            -t $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:$COMMIT_SHA \
-            -t $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:$SHORT_SHA \
-            -t $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:nightly \
-            -t ghcr.io/$_GHCR_OWNER/$REPO_NAME:$COMMIT_SHA \
-            -t ghcr.io/$_GHCR_OWNER/$REPO_NAME:$SHORT_SHA \
-            -t ghcr.io/$_GHCR_OWNER/$REPO_NAME:nightly \
-            -t $_DOCKERHUB_OWNER/$REPO_NAME:$COMMIT_SHA \
-            -t $_DOCKERHUB_OWNER/$REPO_NAME:$SHORT_SHA \
-            -t $_DOCKERHUB_OWNER/$REPO_NAME:nightly \
+            -t $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:$TAG_NAME \
+            -t $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:latest \
+            -t ghcr.io/$_GHCR_OWNER/$REPO_NAME:$TAG_NAME \
+            -t ghcr.io/$_GHCR_OWNER/$REPO_NAME:latest \
+            -t $_DOCKERHUB_OWNER/$REPO_NAME:$TAG_NAME \
+            -t $_DOCKERHUB_OWNER/$REPO_NAME:latest \
             --label org.opencontainers.image.revision=$COMMIT_SHA \
-            --label org.opencontainers.image.version=$COMMIT_SHA \
+            --label org.opencontainers.image.version=$TAG_NAME \
             --label org.opencontainers.image.title=$REPO_NAME \
             --label org.opencontainers.vendor="Sentry" \
             --label org.opencontainers.image.source=https://github.com/$REPO_FULL_NAME \

--- a/cloudbuild.release.yaml
+++ b/cloudbuild.release.yaml
@@ -73,4 +73,4 @@ substitutions:
 
 options:
   machineType: 'E2_HIGHCPU_32'
-  diskSizeGb: 100
+  diskSizeGb: 25

--- a/cloudbuild.release.yaml
+++ b/cloudbuild.release.yaml
@@ -1,8 +1,17 @@
 steps:
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'create-builder'
-    waitFor: ['-']
-    args: ['buildx', 'create', '--driver', 'docker-container', '--name', 'container', '--use']
+  - name: "gcr.io/cloud-builders/docker"
+    id: "create-builder"
+    waitFor: ["-"]
+    args:
+      [
+        "buildx",
+        "create",
+        "--driver",
+        "docker-container",
+        "--name",
+        "container",
+        "--use",
+      ]
 
   # Login to GHCR
   - name: "gcr.io/cloud-builders/docker"
@@ -13,7 +22,7 @@ steps:
       - "-c"
       - "docker login ghcr.io --username $$GHCR_USER --password-stdin <<< $$GHCR_PAT"
     secretEnv: ["GHCR_USER", "GHCR_PAT"]
-  
+
   # Login to Docker Hub
   - name: "gcr.io/cloud-builders/docker"
     id: "dockerhub-auth"
@@ -24,16 +33,15 @@ steps:
       - "docker login --username=$$DOCKERHUB_USER --password-stdin <<< $$DOCKERHUB_PAT"
     secretEnv: ["DOCKERHUB_USER", "DOCKERHUB_PAT"]
 
-
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'build-image'
-    waitFor: ['dockerhub-auth']
-    entrypoint: 'bash'
+  - name: "gcr.io/cloud-builders/docker"
+    id: "build-image"
+    waitFor: ["dockerhub-auth"]
+    entrypoint: "bash"
     args:
-      - '-c'
+      - "-c"
       - |
         set -euxo pipefail
-        
+
         # Build and push with version tags
         docker buildx build \
             --push \
@@ -61,7 +69,7 @@ availableSecrets:
     - versionName: projects/${PROJECT_ID}/secrets/ghcr_user/versions/latest
       env: GHCR_USER
     - versionName: projects/${PROJECT_ID}/secrets/ghcr_pat/versions/latest
-      env: GHCR_PAT 
+      env: GHCR_PAT
     - versionName: projects/${PROJECT_ID}/secrets/dockerhub_user/versions/latest
       env: DOCKERHUB_USER
     - versionName: projects/${PROJECT_ID}/secrets/dockerhub_pat/versions/latest
@@ -71,6 +79,7 @@ substitutions:
   _DOCKERHUB_OWNER: "getsentry"
   _GHCR_OWNER: "getsentry"
 
+logsBucket: "gs://sentryio-cloudbuild-logs"
 options:
-  machineType: 'E2_HIGHCPU_32'
+  machineType: "E2_HIGHCPU_32"
   diskSizeGb: 25

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,7 +53,7 @@ steps:
             --label org.opencontainers.vendor="Sentry" \
             --label org.opencontainers.image.source=https://github.com/$REPO_FULL_NAME \
             --label org.opencontainers.image.url=https://github.com/$REPO_FULL_NAME \
-            --cache-from $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:latest \
+            --cache-from $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:nightly \
             --sbom true \
             --provenance="mode=max" \
             --build-arg UPTIME_CHECKER_GIT_REVISION=$COMMIT_SHA \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,8 +1,17 @@
 steps:
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'create-builder'
-    waitFor: ['-']
-    args: ['buildx', 'create', '--driver', 'docker-container', '--name', 'container', '--use']
+  - name: "gcr.io/cloud-builders/docker"
+    id: "create-builder"
+    waitFor: ["-"]
+    args:
+      [
+        "buildx",
+        "create",
+        "--driver",
+        "docker-container",
+        "--name",
+        "container",
+        "--use",
+      ]
 
   # Login to GHCR
   - name: "gcr.io/cloud-builders/docker"
@@ -13,7 +22,7 @@ steps:
       - "-c"
       - "docker login ghcr.io --username $$GHCR_USER --password-stdin <<< $$GHCR_PAT"
     secretEnv: ["GHCR_USER", "GHCR_PAT"]
-  
+
   # Login to Docker Hub
   - name: "gcr.io/cloud-builders/docker"
     id: "dockerhub-auth"
@@ -24,16 +33,15 @@ steps:
       - "docker login --username=$$DOCKERHUB_USER --password-stdin <<< $$DOCKERHUB_PAT"
     secretEnv: ["DOCKERHUB_USER", "DOCKERHUB_PAT"]
 
-
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'build-image'
-    waitFor: ['dockerhub-auth']
-    entrypoint: 'bash'
+  - name: "gcr.io/cloud-builders/docker"
+    id: "build-image"
+    waitFor: ["dockerhub-auth"]
+    entrypoint: "bash"
     args:
-      - '-c'
+      - "-c"
       - |
         set -euxo pipefail
-        
+
         # Build and push with version tags
         docker buildx build \
             --push \
@@ -64,7 +72,7 @@ availableSecrets:
     - versionName: projects/${PROJECT_ID}/secrets/ghcr_user/versions/latest
       env: GHCR_USER
     - versionName: projects/${PROJECT_ID}/secrets/ghcr_pat/versions/latest
-      env: GHCR_PAT 
+      env: GHCR_PAT
     - versionName: projects/${PROJECT_ID}/secrets/dockerhub_user/versions/latest
       env: DOCKERHUB_USER
     - versionName: projects/${PROJECT_ID}/secrets/dockerhub_pat/versions/latest
@@ -74,6 +82,7 @@ substitutions:
   _DOCKERHUB_OWNER: "getsentry"
   _GHCR_OWNER: "getsentry"
 
+logsBucket: "gs://sentryio-cloudbuild-logs"
 options:
-  machineType: 'E2_HIGHCPU_32'
+  machineType: "E2_HIGHCPU_32"
   diskSizeGb: 25

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,7 +53,7 @@ steps:
             --label org.opencontainers.vendor="Sentry" \
             --label org.opencontainers.image.source=https://github.com/$REPO_FULL_NAME \
             --label org.opencontainers.image.url=https://github.com/$REPO_FULL_NAME \
-            --cache-from $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:$COMMIT_SHA \
+            --cache-from $LOCATION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/image:latest \
             --sbom true \
             --provenance="mode=max" \
             --build-arg UPTIME_CHECKER_GIT_REVISION=$COMMIT_SHA \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -76,4 +76,4 @@ substitutions:
 
 options:
   machineType: 'E2_HIGHCPU_32'
-  diskSizeGb: 100
+  diskSizeGb: 25


### PR DESCRIPTION
In preparation for our standardized/templated Cloud Build configuration. See https://github.com/getsentry/ops/pull/1580

All of the builds that push to a registry will include SBOMs and provenance data/annotations. In a future PR, will include attestation and signing of the images.

## `cloudbuild.ci.yaml`
- **will trigger on PRs targeting `main`**
- images will **not** be pushed to any registry
- uses `latest` as the cache source to speed up build times

## `cloudbuild.yaml`
- **will trigger on pushes to `main`**
- images will be pushed to GHCR, Docker Hub, and Google Artifact Registry
- image tags include: full commit sha, the short sha, and `nightly`
- uses `nightly` (ie. the previously build main) as the cache source to speed up build times

## `cloudbuild.release.yaml`
- **will trigger on pushes to release tags** (see required pattern match in https://github.com/getsentry/ops/pull/15807)
- images will be pushed to GHCR, Docker Hub, and Google Artifact Registry
- image tags include: the "tag name" (ex. 25.6.0) and `latest`
- uses the full commit sha as the cache source to speed up build times. 
  - This will be available since the `main` branch will already have built and pushed it.

> [!NOTE]
> Cloud Build will fail on this PR with the current repository and trigger configuration. It will not have access to the necessary secrets as we are moving to a more secure pattern using specific GCP service accounts for the various build types.