### PR TITLE
chore: bump Rust toolchain version to 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uptime-checker"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80-alpine3.20 as builder
+FROM rust:1.85-alpine3.20 as builder
 
 # Install system dependencies
 RUN apk add --no-cache \

--- a/Dockerfile.localdev
+++ b/Dockerfile.localdev
@@ -11,7 +11,7 @@
 # so you can test your changes without having to rebuild the container.
 ##
 
-FROM rust:1.80-alpine3.20 as builder
+FROM rust:1.85-alpine3.20 as builder
 
 ARG UPTIME_CHECKER_GIT_REVISION
 ENV UPTIME_CHECKER_GIT_REVISION=$UPTIME_CHECKER_GIT_REVISION

--- a/build.rs
+++ b/build.rs
@@ -15,8 +15,8 @@ fn emit_version() {
             .unwrap_or("unknown-rev".to_string())
     });
 
-    let release_name = format!("{}@{}+{}", package_name, package_version, git_commit_sha);
-    println!("cargo:rustc-env=UPTIME_CHECKER_VERSION={}", release_name);
+    let release_name = format!("{package_name}@{package_version}+{git_commit_sha}");
+    println!("cargo:rustc-env=UPTIME_CHECKER_VERSION={release_name}");
 }
 
 fn main() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,7 +44,7 @@ pub fn execute() -> io::Result<()> {
                         match result {
                             None => panic!("tasks_finished channel unexpectedly closed"),
                             Some(Err(err)) => {
-                                panic!("Error in partition: {:?}", err);
+                                panic!("Error in partition: {err:?}");
                             },
                             _ => panic!("Unexpected end of task"),
                         }

--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -26,8 +26,8 @@ impl RedisPartition {
     pub fn new(number: u16) -> RedisPartition {
         RedisPartition {
             number,
-            config_key: format!("uptime:configs:{}", number),
-            update_key: format!("uptime:updates:{}", number),
+            config_key: format!("uptime:configs:{number}"),
+            update_key: format!("uptime:updates:{number}"),
         }
     }
 }

--- a/src/checker/isahc_checker.rs
+++ b/src/checker/isahc_checker.rs
@@ -241,7 +241,7 @@ impl Checker for IsahcChecker {
                         tracing::info!("check_url.error: {:?}", error_msg);
                         CheckStatusReason {
                             status_type: CheckStatusReasonType::Failure,
-                            description: format!("{:?}", error_msg),
+                            description: format!("{error_msg:?}"),
                         }
                     }
                 }
@@ -919,7 +919,7 @@ mod tests {
         };
         let check = ScheduledCheck::new_for_test(tick, config);
         let result = checker.check_url(&check, "us-west").await;
-        eprintln!("{:?}", result);
+        eprintln!("{result:?}");
 
         assert_eq!(result.status, CheckStatus::Failure);
         assert_eq!(result.request_info.and_then(|i| i.http_status_code), None);
@@ -930,8 +930,7 @@ mod tests {
         let result_description = result.status_reason.map(|r| r.description).unwrap();
         assert_eq!(
             result_description, "unknown error",
-            "Expected error message about closed connection: {}",
-            result_description
+            "Expected error message about closed connection: {result_description}"
         );
     }
 }

--- a/src/checker/isahc_checker.rs
+++ b/src/checker/isahc_checker.rs
@@ -758,26 +758,22 @@ mod tests {
             assert_eq!(
                 result.status,
                 CheckStatus::Failure,
-                "Test case: {:?}",
-                &cert_type
+                "Test case: {&cert_type:?}",
             );
             assert_eq!(
                 result.request_info.and_then(|i| i.http_status_code),
                 None,
-                "Test case: {:?}",
-                cert_type
+                "Test case: {cert_type:?}",
             );
             assert_eq!(
                 result.status_reason.as_ref().map(|r| r.status_type),
                 Some(CheckStatusReasonType::TlsError),
-                "Test case: {:?}",
-                cert_type
+                "Test case: {cert_type:?}",
             );
             assert_eq!(
                 result.status_reason.map(|r| r.description).unwrap(),
                 expected_msg,
-                "Test case: {:?}",
-                cert_type
+                "Test case: {cert_type:?}",
             );
         }
     }
@@ -888,8 +884,7 @@ mod tests {
         let result_description = result.status_reason.map(|r| r.description).unwrap();
         assert_eq!(
             result_description, "unknown error",
-            "Expected error message about closed connection: {}",
-            result_description
+            "Expected error message about closed connection: {result_description}",
         );
     }
 

--- a/src/checker/isahc_checker.rs
+++ b/src/checker/isahc_checker.rs
@@ -758,7 +758,7 @@ mod tests {
             assert_eq!(
                 result.status,
                 CheckStatus::Failure,
-                "Test case: {&cert_type:?}",
+                "Test case: {cert_type:?}",
             );
             assert_eq!(
                 result.request_info.and_then(|i| i.http_status_code),

--- a/src/checker/reqwest_checker.rs
+++ b/src/checker/reqwest_checker.rs
@@ -814,7 +814,7 @@ mod tests {
             assert_eq!(
                 result.status,
                 CheckStatus::Failure,
-                "Test case: {&cert_type:?}",
+                "Test case: {cert_type:?}",
             );
             assert_eq!(
                 result.request_info.and_then(|i| i.http_status_code),

--- a/src/checker/reqwest_checker.rs
+++ b/src/checker/reqwest_checker.rs
@@ -95,7 +95,7 @@ fn dns_error(err: &reqwest::Error) -> Option<String> {
         inner = source;
 
         if let Some(inner_err) = source.downcast_ref::<hickory_resolver::error::ResolveError>() {
-            return Some(format!("{}", inner_err));
+            return Some(format!("{inner_err}"));
         }
     }
     None
@@ -348,7 +348,7 @@ impl Checker for ReqwestChecker {
                     tracing::info!("check_url.error: {:?}", error_msg);
                     CheckStatusReason {
                         status_type: CheckStatusReasonType::Failure,
-                        description: format!("{:?}", error_msg),
+                        description: format!("{error_msg:?}"),
                     }
                 }
             }),

--- a/src/checker/reqwest_checker.rs
+++ b/src/checker/reqwest_checker.rs
@@ -814,26 +814,22 @@ mod tests {
             assert_eq!(
                 result.status,
                 CheckStatus::Failure,
-                "Test case: {:?}",
-                &cert_type
+                "Test case: {&cert_type:?}",
             );
             assert_eq!(
                 result.request_info.and_then(|i| i.http_status_code),
                 None,
-                "Test case: {:?}",
-                cert_type
+                "Test case: {cert_type:?}",
             );
             assert_eq!(
                 result.status_reason.as_ref().map(|r| r.status_type),
                 Some(CheckStatusReasonType::TlsError),
-                "Test case: {:?}",
-                cert_type
+                "Test case: {cert_type:?}",
             );
             assert_eq!(
                 result.status_reason.map(|r| r.description).unwrap(),
                 expected_msg,
-                "Test case: {:?}",
-                cert_type
+                "Test case: {cert_type:?}",
             );
         }
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -37,7 +37,7 @@ pub struct PartitionedService {
 }
 
 pub fn build_progress_key(partition: u16) -> String {
-    format!("scheduler_process::{}", partition).to_string()
+    format!("scheduler_process::{partition}").to_string()
 }
 
 impl PartitionedService {

--- a/src/types/check_config.rs
+++ b/src/types/check_config.rs
@@ -683,10 +683,7 @@ mod tests {
             for other_region in should_run_order.iter().filter(|&&r| r != expected_region) {
                 assert!(
                     !config.should_run(tick, other_region),
-                    "Subscription {} should not run in region {} at tick {}",
-                    subscription_id,
-                    other_region,
-                    tick
+                    "Subscription {subscription_id} should not run in region {other_region} at tick {tick}"
                 );
             }
         }


### PR DESCRIPTION
Bumps the Rust version to 1.85 and fixes the new lints.
Needed for #324 