### PR TITLE
ci: Cleanup image builder

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -82,8 +82,8 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
           tags: |
-            type=sha,
-            type=sha,format=long
+            type=sha,prefix=
+            type=sha,prefix=,format=long
             type=raw,value=nightly,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
           labels: |
             org.opencontainers.image.title=uptime-checker
@@ -98,11 +98,11 @@ jobs:
         uses: docker/build-push-action@32945a339266b759abcbdc89316275140b0fc960 # v6.8.10
         with:
           context: .
-          push: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || startsWith(github.ref, 'refs/heads/release/') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/${{ matrix.platform }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:nightly
           cache-to: type=inline
-          sbom: true
           provenance: "mode=max"
-          platforms: linux/${{ matrix.platform }}
+          sbom: true
+          push: true


### PR DESCRIPTION
- Correct sha release prefix's (we want nothing)
 - Remove extraneous logic on push condition