### PR TITLE
ci: Remove release-ghcr-version-tag

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -9,7 +9,6 @@ statusProvider:
     contexts:
       - 'build-amd64'
       - 'build-arm64'
-      - 'release-ghcr-version-tag'
 
 targets:
   - name: github


### PR DESCRIPTION
This job happens once the release is created