### PR TITLE
ci: use gha for cache

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -35,8 +35,7 @@ jobs:
         uses: docker/build-push-action@32945a339266b759abcbdc89316275140b0fc960 # v6.8.10
         with:
           context: .
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ matrix.platform }}
-          cache-to:
+          cache-from: type=gha
           platforms: linux/${{ matrix.platform }}
           tags: ghcr.io/${{ github.repository }}:${{ github.sha }}-${{ matrix.platform }}
           push: false
@@ -106,8 +105,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/${{ matrix.platform }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ matrix.platform }}
-          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache-${{ matrix.platform }},mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           annotations: ${{ steps.meta.outputs.annotations }}
           provenance: mode=max
           sbom: true
@@ -148,4 +147,3 @@ jobs:
             "${{ github.repository }}" \
             "${{ github.sha }}" \
             "${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}"
-


### PR DESCRIPTION
Interested to see if using GHA's cache works here. It'd keep the GHCR less polluted with tags.