### PR TITLE
fix: remediate dockerfile syntax warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-alpine3.20 as builder
+FROM rust:1.85-alpine3.20 AS builder
 
 # Install system dependencies
 RUN apk add --no-cache \


### PR DESCRIPTION
Fixing a syntax warning in the docker builds.

```
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
 ```