### PR TITLE
Reapply "chore: bump Rust toolchain version to 1.85 (#325)" (#367)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uptime-checker"
 version = "25.7.0"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.85"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM rust:1.80-alpine3.20 as builder
-
+FROM rust:1.85-alpine3.20 AS builder
 
 # Install system dependencies
 RUN apk add --no-cache \

--- a/Dockerfile.localdev
+++ b/Dockerfile.localdev
@@ -11,7 +11,7 @@
 # so you can test your changes without having to rebuild the container.
 ##
 
-FROM rust:1.80-alpine3.20 as builder
+FROM rust:1.85-alpine3.20 as builder
 
 ARG UPTIME_CHECKER_GIT_REVISION
 ENV UPTIME_CHECKER_GIT_REVISION=$UPTIME_CHECKER_GIT_REVISION


### PR DESCRIPTION
This reverts commit 19986da0102b2680fbd6dffb0386162a9b0682e8.

This also doesn't appear to be the problem causing deploys to fail