### PR TITLE
fix(docker): Add ca-certificates to production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ RUN cargo build --release
 
 FROM alpine:3.22.1
 
-RUN apk add --no-cache tini libgcc curl && \
+RUN apk add --no-cache tini libgcc curl ca-certificates && \
+    apk upgrade --no-cache ca-certificates && \
     addgroup -S app --gid 1000 && \
     adduser -S app -G app --uid 1000
 


### PR DESCRIPTION
## Summary
- Adds ca-certificates package to the production Docker image to fix TLS certificate verification failures
- Ensures the certificates are upgraded to the latest version during build

## Problem
The uptime-checker was failing with "tls_error - certificate verify failed" errors for some HTTPS sites. Investigation revealed that the production Dockerfile was missing the `ca-certificates` package, which meant the container had no root CA certificates to validate SSL/TLS connections against.

This particularly affected sites using newer certificate chains (like those from Cloudflare using SSL.com intermediate certificates) that weren't included in the base Alpine image.

## Solution
Added `ca-certificates` to the package installation in the production Dockerfile and ensured it's upgraded to the latest version. This provides the necessary root CA certificates for proper SSL/TLS validation.

## Test plan
- [x] Built the Docker image locally and verified ca-certificates is installed
- [x] Confirmed the /etc/ssl/certs/ directory is properly populated with certificates
- [x] Verified that SSL.com and other modern root certificates are included