### PR TITLE
Optimize ca-certificates layer for better updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,12 +42,15 @@ RUN cargo build --release
 
 FROM alpine:3.22.1
 
-RUN apk add --no-cache tini libgcc curl ca-certificates && \
-    apk upgrade --no-cache ca-certificates && \
+RUN apk add --no-cache tini libgcc curl && \
     addgroup -S app --gid 1000 && \
     adduser -S app -G app --uid 1000
 
 COPY --from=builder /app/target/release/uptime-checker /usr/local/bin/uptime-checker
+
+# Install ca-certificates after COPY so they get updated when the binary changes
+RUN apk add --no-cache ca-certificates && \
+    apk upgrade --no-cache ca-certificates
 
 USER app
 


### PR DESCRIPTION
## Summary
- Moves ca-certificates installation to a separate layer after the binary COPY
- Ensures ca-certificates get updated whenever the application binary changes

## Motivation
Previously, ca-certificates were installed early in the Dockerfile, which meant they only got updated when the base image or earlier layers changed. This could lead to outdated CA certificates causing TLS verification failures.

## Changes
- Split the RUN command to install base dependencies first (tini, libgcc, curl)
- Install ca-certificates in a separate layer after copying the binary
- This ensures more frequent trust store updates as the binary changes regularly

## Test plan
- Built the Docker image locally and verified ca-certificates are properly installed
- Confirmed the image builds successfully with the new layer ordering