### PR TITLE
feat(build): add action-build-and-push-images to build production images published to GAR (part 1)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -28,17 +28,19 @@ jobs:
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-
-      - name: Build
-        uses: docker/build-push-action@32945a339266b759abcbdc89316275140b0fc960 # v6.8.10
+      - name: Build image
+        uses: getsentry/action-build-and-push-images@a53f146fc1ea3cb404f2dcf7378f5b60dd98d3ca
         with:
-          context: .
-          cache-from: type=gha,scope=${{ matrix.platform }}
+          image_name: ${{ github.repository }}
           platforms: linux/${{ matrix.platform }}
-          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}-${{ matrix.platform }}
-          push: false
+          dockerfile_path: './Dockerfile'
+          build_args: UPTIME_CHECKER_GIT_REVISION=${{ github.sha }}
+          ghcr: true
+          tag_suffix: -${{ matrix.platform }}
+          publish_on_pr: false
+          google_ar: false
+          tag_nightly: false
+          tag_latest: false
 
   build-main-or-release:
     name: build-${{ matrix.platform }}


### PR DESCRIPTION
the goal is to comply with the artifact management standard here: https://www.notion.so/sentry/Standard-Spec-Artifact-Management-22a8b10e4b5d80ecb6dcca3eb4558f5b

this adds our composite action which will build images in GHA and publish to GAR

these images temporarily have a `-gha` suffix so GoCD won't deploy them, a followup PR will add `-cloudbuild` suffix to cloudbuilds to disable use of them and remove `-gha` so GoCD cuts over to using images in GAR
