### PR TITLE
fix(uptime): clean up some recv() usage and vec allocs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3239,10 +3239,12 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg 0.52.0",
 ]
@@ -4986,6 +4988,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4736,7 +4736,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uptime-checker"
-version = "26.5.2"
+version = "26.6.0"
 dependencies = [
  "anyhow",
  "associative-cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ hyper = { git = "https://github.com/getsentry/hyper", rev = "9efa5aedce8a36e9a86
 hyper-util = { git = "https://github.com/getsentry/hyper-util", rev = "cff84af9d682add40b92c5a57ad43f73bb714081" }
 reqwest = { git = "https://github.com/getsentry/reqwest-uptime", rev = "a4846d12afbf0d01598300c46055202a8e47de95", features = [
   "hickory-dns",
+  "stream",
 ] }
 anyhow = "1.0.66"
 clap = { version = "4.4.6", features = ["derive"] }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -172,6 +172,9 @@ pub struct Config {
     /// The batch size to use for vector producer
     pub vector_batch_size: usize,
 
+    /// The timeout to control batch flushing for vector producer
+    pub vector_batch_timeout_secs: u64,
+
     /// The vector endpoint to send results to
     pub vector_endpoint: String,
 
@@ -270,6 +273,7 @@ impl Default for Config {
             checker_mode: CheckerMode::Reqwest,
             vector_batch_size: 10,
             vector_endpoint: "http://localhost:8020".to_owned(),
+            vector_batch_timeout_secs: 10,
             retry_vector_errors_forever: false,
             producer_mode: ProducerMode::Kafka,
             config_provider_redis_update_ms: 1000,
@@ -455,6 +459,7 @@ mod tests {
                         total_checkers: 1,
                         producer_mode: ProducerMode::Kafka,
                         vector_batch_size: 10,
+                        vector_batch_timeout_secs: 10,
                         vector_endpoint: "http://localhost:8020".to_owned(),
                         retry_vector_errors_forever: false,
                         failure_retries: 0,
@@ -528,6 +533,7 @@ mod tests {
                 ("UPTIME_CHECKER_WEBSERVER_PORT", "81"),
                 ("UPTIME_CHECKER_ASSERTION_COMPLEXITY", "120"),
                 ("UPTIME_CHECKER_MAX_ASSERTION_OPS", "15"),
+                ("UPTIME_CHECKER_VECTOR_BATCH_TIMEOUT_SECS", "11"),
             ],
             |config| {
                 assert_eq!(
@@ -574,6 +580,7 @@ mod tests {
                         total_checkers: 5,
                         producer_mode: ProducerMode::Kafka,
                         vector_batch_size: 10,
+                        vector_batch_timeout_secs: 11,
                         vector_endpoint: "http://localhost:8020".to_owned(),
                         retry_vector_errors_forever: false,
                         failure_retries: 2,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -192,6 +192,7 @@ impl Manager {
                     &config.results_kafka_topic,
                     config.vector_endpoint.clone(),
                     config.vector_batch_size,
+                    config.vector_batch_timeout_secs,
                     config.retry_vector_errors_forever,
                     config.region.to_owned(),
                 );

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -73,22 +73,19 @@ impl VectorResultsProducer {
             let region: &'static str = config.region.clone().leak();
             let mut batch = Vec::with_capacity(config.vector_batch_size);
 
-            while let Some(json) = receiver.recv().await {
-                let new_count = pending_items.fetch_sub(1, Ordering::Relaxed);
-                metrics::gauge!("producer.pending_items").set(new_count as f64);
+            while receiver
+                .recv_many(&mut batch, config.vector_batch_size)
+                .await
+                > 0
+            {
+                let new_count = pending_items.fetch_sub(batch.len(), Ordering::Relaxed);
+                metrics::gauge!("producer.pending_items", "uptime_region" => region)
+                    .set(new_count as f64);
 
-                batch.push(json);
-
-                if batch.len() < config.vector_batch_size {
-                    continue;
-                }
-
-                let batch_to_send =
-                    std::mem::replace(&mut batch, Vec::with_capacity(config.vector_batch_size));
                 if let Err(e) = {
                     let start = std::time::Instant::now();
                     let result = send_batch(
-                        batch_to_send,
+                        &mut batch,
                         client.clone(),
                         config.endpoint.clone(),
                         config.retry_vector_errors_forever,
@@ -104,7 +101,7 @@ impl VectorResultsProducer {
 
             if !batch.is_empty() {
                 if let Err(e) = send_batch(
-                    batch,
+                    &mut batch,
                     client,
                     config.endpoint,
                     config.retry_vector_errors_forever,
@@ -141,7 +138,7 @@ impl ResultsProducer for VectorResultsProducer {
 }
 
 async fn send_batch(
-    batch: Vec<Vec<u8>>,
+    batch: &mut Vec<Vec<u8>>,
     client: Client,
     endpoint: String,
     retry_vector_errors_forever: bool,
@@ -151,11 +148,14 @@ async fn send_batch(
         return Ok(());
     }
 
-    let body: String = batch
-        .iter()
-        .filter_map(|json| String::from_utf8(json.clone()).ok())
-        .map(|s| s + "\n")
-        .collect();
+    let vec_size = batch.iter().fold(0, |acc, b| acc + b.len() + 1);
+    let batch_len = batch.len();
+
+    let mut body = Vec::with_capacity(vec_size);
+    for s in batch.drain(..) {
+        body.extend(s);
+        body.push(b'\n');
+    }
 
     const BASE_DELAY_MS: u64 = 100;
     const MAX_DELAY_MS: u64 = 2000;
@@ -208,7 +208,7 @@ async fn send_batch(
                             status = ?resp.status(),
                             retry = num_of_retries,
                             delay_ms = ?delay.as_millis(),
-                            batch_size = batch.len(),
+                            batch_size = batch_len,
                             "request.failed_to_vector_retrying"
                         );
                     }
@@ -216,7 +216,7 @@ async fn send_batch(
                         tracing::warn!(
                             error = ?e,
                             retry = num_of_retries,
-                            batch_size = batch.len(),
+                            batch_size = batch_len,
                             delay_ms = ?delay.as_millis(),
                             "request.failed_to_vector_retrying"
                         );

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -167,8 +167,9 @@ async fn send_batch(
         let response = client.execute(req).await;
         let stats = hyper::stats::consume_request_stats(req_id);
         // Calculate delay with a maximum cap
-        let delay =
-            Duration::from_millis((BASE_DELAY_MS * (2_u64.pow(num_of_retries))).min(MAX_DELAY_MS));
+        let delay = Duration::from_millis(
+            (BASE_DELAY_MS * (2_u64.pow(num_of_retries.min(63)))).min(MAX_DELAY_MS),
+        );
 
         match response {
             Ok(resp) if !resp.status().is_server_error() => {

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -1,7 +1,6 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::Instant;
 
 use crate::producer::{ExtractCodeError, ResultsProducer};
 use crate::types::result::CheckResult;
@@ -9,7 +8,9 @@ use reqwest::Client;
 use sentry_kafka_schemas::Schema;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
-use tokio::time::{sleep, timeout_at};
+use tokio::time::sleep;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::StreamExt;
 
 struct VectorRequestWorkerConfig {
     vector_batch_size: usize,
@@ -68,7 +69,7 @@ impl VectorResultsProducer {
     fn spawn_worker(
         config: VectorRequestWorkerConfig,
         client: Client,
-        mut receiver: UnboundedReceiver<Vec<u8>>,
+        receiver: UnboundedReceiver<Vec<u8>>,
         pending_items: Arc<AtomicUsize>,
     ) -> JoinHandle<()> {
         tracing::info!("vector_worker.starting");
@@ -76,70 +77,34 @@ impl VectorResultsProducer {
         tokio::spawn(async move {
             // Avoid cloning this string over and over again.
             let region: &'static str = config.region.clone().leak();
-            let mut batch = Vec::with_capacity(config.vector_batch_size);
-            let mut batch_element_remaining = config.vector_batch_size;
-            let timeout_duration: Duration = Duration::from_secs(config.vector_batch_timeout_secs);
-            let mut deadline = Instant::now()
-                .checked_add(timeout_duration)
-                .expect("timeout_duration is small");
+            let receiver_stream = UnboundedReceiverStream::new(receiver);
 
-            loop {
-                let receive_fut = receiver.recv_many(&mut batch, batch_element_remaining);
-                let result = timeout_at(deadline.into(), receive_fut).await;
+            let chunk_stream = receiver_stream.chunks_timeout(
+                config.vector_batch_size,
+                Duration::from_secs(config.vector_batch_timeout_secs),
+            );
 
-                match result {
-                    Ok(num_read) => {
-                        if num_read == 0 {
-                            break;
-                        }
-                        batch_element_remaining -= num_read;
-                    }
-                    Err(_) => batch_element_remaining = 0,
-                }
+            tokio::pin!(chunk_stream);
 
-                if batch_element_remaining > 0 {
-                    continue;
-                }
+            while let Some(batch) = chunk_stream.next().await {
+                let new_count = pending_items.fetch_sub(batch.len(), Ordering::Relaxed);
+                metrics::gauge!("producer.pending_items", "uptime_region" => region)
+                    .set(new_count as f64);
 
-                if !batch.is_empty() {
-                    let new_count = pending_items.fetch_sub(batch.len(), Ordering::Relaxed);
-                    metrics::gauge!("producer.pending_items", "uptime_region" => region)
-                        .set(new_count as f64);
-
-                    if let Err(e) = {
-                        let start = std::time::Instant::now();
-                        let result = send_batch(
-                            &mut batch,
-                            client.clone(),
-                            config.endpoint.clone(),
-                            config.retry_vector_errors_forever,
-                            region,
-                        )
-                        .await;
-                        metrics::histogram!("vector_producer.send_batch.duration", "uptime_region" => region, "histogram" => "timer").record(start.elapsed().as_secs_f64());
-                        result
-                    } {
-                        tracing::error!(error = %e, "vector_batch.send_failed");
-                    }
-                }
-
-                batch_element_remaining = config.vector_batch_size;
-                deadline = Instant::now()
-                    .checked_add(timeout_duration)
-                    .expect("timeout_duration is small");
-            }
-
-            if !batch.is_empty() {
-                if let Err(e) = send_batch(
-                    &mut batch,
-                    client,
-                    config.endpoint,
-                    config.retry_vector_errors_forever,
-                    region,
-                )
-                .await
-                {
-                    tracing::error!(error = %e, "final_batch.send_failed");
+                if let Err(e) = {
+                    let start = std::time::Instant::now();
+                    let result = send_batch(
+                        batch,
+                        client.clone(),
+                        config.endpoint.clone(),
+                        config.retry_vector_errors_forever,
+                        region,
+                    )
+                    .await;
+                    metrics::histogram!("vector_producer.send_batch.duration", "uptime_region" => region, "histogram" => "timer").record(start.elapsed().as_secs_f64());
+                    result
+                } {
+                    tracing::error!(error = %e, "vector_batch.send_failed");
                 }
             }
 
@@ -168,7 +133,7 @@ impl ResultsProducer for VectorResultsProducer {
 }
 
 async fn send_batch(
-    batch: &mut Vec<Vec<u8>>,
+    mut batch: Vec<Vec<u8>>,
     client: Client,
     endpoint: String,
     retry_vector_errors_forever: bool,

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -168,7 +168,7 @@ async fn send_batch(
         let stats = hyper::stats::consume_request_stats(req_id);
         // Calculate delay with a maximum cap
         let delay =
-            Duration::from_millis((BASE_DELAY_MS * (2_u64.pow(num_of_retries))).max(MAX_DELAY_MS));
+            Duration::from_millis((BASE_DELAY_MS * (2_u64.pow(num_of_retries))).min(MAX_DELAY_MS));
 
         match response {
             Ok(resp) if !resp.status().is_server_error() => {

--- a/src/producer/vector_producer.rs
+++ b/src/producer/vector_producer.rs
@@ -1,5 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
 
 use crate::producer::{ExtractCodeError, ResultsProducer};
 use crate::types::result::CheckResult;
@@ -7,10 +9,11 @@ use reqwest::Client;
 use sentry_kafka_schemas::Schema;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
-use tokio::time::{sleep, Duration};
+use tokio::time::{sleep, timeout_at};
 
 struct VectorRequestWorkerConfig {
     vector_batch_size: usize,
+    vector_batch_timeout_secs: u64,
     endpoint: String,
     retry_vector_errors_forever: bool,
     region: String,
@@ -27,6 +30,7 @@ impl VectorResultsProducer {
         topic_name: &str,
         endpoint: String,
         vector_batch_size: usize,
+        vector_batch_timeout_secs: u64,
         retry_vector_errors_forever: bool,
         region: String,
     ) -> (Self, JoinHandle<()>) {
@@ -42,6 +46,7 @@ impl VectorResultsProducer {
 
         let config = VectorRequestWorkerConfig {
             vector_batch_size,
+            vector_batch_timeout_secs,
             endpoint,
             retry_vector_errors_forever,
             region,
@@ -72,38 +77,56 @@ impl VectorResultsProducer {
             // Avoid cloning this string over and over again.
             let region: &'static str = config.region.clone().leak();
             let mut batch = Vec::with_capacity(config.vector_batch_size);
-            let mut batch_element_count = 0;
+            let mut batch_element_remaining = config.vector_batch_size;
+            let timeout_duration: Duration = Duration::from_secs(config.vector_batch_timeout_secs);
+            let mut deadline = Instant::now()
+                .checked_add(timeout_duration)
+                .expect("timeout_duration is small");
 
-            while receiver
-                .recv_many(&mut batch, config.vector_batch_size - batch_element_count)
-                .await
-                > 0
-            {
-                if batch.len() < config.vector_batch_size {
-                    batch_element_count = batch.len();
+            loop {
+                let receive_fut = receiver.recv_many(&mut batch, batch_element_remaining);
+                let result = timeout_at(deadline.into(), receive_fut).await;
+
+                match result {
+                    Ok(num_read) => {
+                        if num_read == 0 {
+                            break;
+                        }
+                        batch_element_remaining -= num_read;
+                    }
+                    Err(_) => batch_element_remaining = 0,
+                }
+
+                if batch_element_remaining > 0 {
                     continue;
                 }
-                batch_element_count = 0;
 
-                let new_count = pending_items.fetch_sub(batch.len(), Ordering::Relaxed);
-                metrics::gauge!("producer.pending_items", "uptime_region" => region)
-                    .set(new_count as f64);
+                if !batch.is_empty() {
+                    let new_count = pending_items.fetch_sub(batch.len(), Ordering::Relaxed);
+                    metrics::gauge!("producer.pending_items", "uptime_region" => region)
+                        .set(new_count as f64);
 
-                if let Err(e) = {
-                    let start = std::time::Instant::now();
-                    let result = send_batch(
-                        &mut batch,
-                        client.clone(),
-                        config.endpoint.clone(),
-                        config.retry_vector_errors_forever,
-                        region,
-                    )
-                    .await;
-                    metrics::histogram!("vector_producer.send_batch.duration", "uptime_region" => region, "histogram" => "timer").record(start.elapsed().as_secs_f64());
-                    result
-                } {
-                    tracing::error!(error = %e, "vector_batch.send_failed");
+                    if let Err(e) = {
+                        let start = std::time::Instant::now();
+                        let result = send_batch(
+                            &mut batch,
+                            client.clone(),
+                            config.endpoint.clone(),
+                            config.retry_vector_errors_forever,
+                            region,
+                        )
+                        .await;
+                        metrics::histogram!("vector_producer.send_batch.duration", "uptime_region" => region, "histogram" => "timer").record(start.elapsed().as_secs_f64());
+                        result
+                    } {
+                        tracing::error!(error = %e, "vector_batch.send_failed");
+                    }
                 }
+
+                batch_element_remaining = config.vector_batch_size;
+                deadline = Instant::now()
+                    .checked_add(timeout_duration)
+                    .expect("timeout_duration is small");
             }
 
             if !batch.is_empty() {
@@ -308,6 +331,7 @@ mod tests {
             "uptime-results",
             mock_server.url("/").to_string(),
             TEST_BATCH_SIZE,
+            10,
             false,
             "us-west-1".to_string(),
         );
@@ -365,6 +389,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_batch_timeout() {
+        let mock_server = MockServer::start();
+        let (producer, _) = VectorResultsProducer::new(
+            "uptime-results",
+            mock_server.url("/").to_string(),
+            TEST_BATCH_SIZE,
+            1,
+            false,
+            "us-west-1".to_string(),
+        );
+
+        // Only send one event
+        let test_result = create_test_result();
+        let result = producer.produce_checker_result(&test_result);
+        assert!(result.is_ok());
+
+        // Mock for full batch and remainder
+        let mock = mock_server.mock(|when, then| {
+            when.method(Method::POST)
+                .path("/")
+                .header("Content-Type", "application/json")
+                .matches(|req| {
+                    if let Some(body) = &req.body {
+                        let lines: Vec<_> = body
+                            .split(|&b| b == b'\n')
+                            .filter(|l| !l.is_empty())
+                            .collect();
+
+                        // Verify each line is valid JSON with expected fields
+                        lines.iter().all(|line| {
+                            if let Ok(value) = serde_json::from_slice::<serde_json::Value>(line) {
+                                return value["subscription_id"]
+                                    == "23d6048d67c948d9a19c0b47979e9a03"
+                                    && value["status"] == "success"
+                                    && value["region"] == "us-west-1";
+                            }
+                            false
+                        })
+                    } else {
+                        false
+                    }
+                });
+            then.status(200);
+        });
+
+        // Waiting, but a bit shy of the timeout
+        sleep(Duration::from_millis(500)).await;
+
+        // We shouldn't have breached the timeout, so assert that nothing has been produced
+        mock.assert_hits(0);
+
+        // Wait a bit for the timeout to definitely have been breached
+        sleep(Duration::from_secs(1)).await;
+
+        // We should have got something by now
+        mock.assert_hits(1);
+    }
+
+    #[tokio::test]
     async fn test_flush_on_shutdown() {
         let mock_server = MockServer::start();
         // Create a mock that expects a single request with less than BATCH_SIZE events
@@ -397,6 +480,7 @@ mod tests {
             "uptime-results",
             mock_server.url("/").to_string(),
             TEST_BATCH_SIZE,
+            10,
             false,
             "us-west-1".to_string(),
         );


### PR DESCRIPTION
In regions with very few uptime subscriptions (i.e. bringing up a new region,) we will block sending results to vector until we've accumulated enough results.  This bounds that buffering with an upper-bound of default 10 seconds.