### PR TITLE
Cargo.toml - enable TLS on redis crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,12 @@ metrics-exporter-statsd = "0.8.0"
 metrics = "0.23.0"
 futures = "0.3.30"
 tokio-stream = "0.1.15"
-redis = { version = "0.30.0", features = ["cluster-async", "tokio-comp"] }
+redis = { version = "0.30.0", features = [
+  "cluster-async",
+  "tokio-comp",
+  "tls-rustls",
+  "tokio-rustls-comp"
+] }
 ipnet = "2.11.0"
 hickory-resolver = "0.24.1"
 tokio-rustls = "0.26.1"


### PR DESCRIPTION
Hello,

We use a self hosted version of Sentry. In our setup we use Redis with TLS encryption (AWS Elasticache) which works well with other components of Sentry, but not uptime-checker.

Enabling support for TLS on the redis crate fixes this issue. For other methods of self hosting Redis, one might wish to enable 'tls-rustls-insecure' as well (to allow self signed certificates).

I did take a look at previous PRs and issues and I did not spot any previous mention of this, my bad if I overlooked something!