### PR TITLE
chore(gocd): bump gocd-jsonnet to v2.19.0 to disable fetch_materials on pipeline-complete

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v2.10.0"
+      "version": "v2.19.0"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "74ae5728e2d7ed39fdd43cf3b2d28dde7e4567a1",
-      "sum": "AKMGYALLyaVVVjTNnZy64PoCDA8QjxTbHBe5dCnE4tE="
+      "version": "56cc4d91cbaac4569b37b4911998b48c2f9c2ac4",
+      "sum": "J0D//go/146qfReWFTTL5xWWCVlkTjqhnALYPH4Z9rE="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
- Bumps `gocd-jsonnet` from v2.18.0 to v2.19.0
- v2.19.0 sets `fetch_materials: false` on all `pipeline-complete` stages, eliminating unnecessary git material fetching that was causing multi-minute delays on the single static GoCD agent
- Addresses [DI-1685](https://linear.app/getsentry/issue/DI-1685)