### PR TITLE
chore: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/fast-revert.yml
+++ b/.github/workflows/fast-revert.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Get auth token
         id: token
-        uses: getsentry/action-github-app-token@v3.0.0
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         with:
           app_id: ${{ vars.FAST_REVERT_BOT_APP_ID }}
           private_key: ${{ secrets.GH_FAST_REVERT_PRIVATE_KEY }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/self-hosted@master
+        uses: getsentry/self-hosted@871c182cb0a99dc1fad72cc7ce7889b514b0c5f0 # master
         with:
           project_name: uptime_checker
           image_url: ghcr.io/getsentry/uptime-checker:${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,7 +62,7 @@ jobs:
         run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy --no-self-update
 
       - name: Cache rust cargo artifacts
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4736,7 +4736,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uptime-checker"
-version = "26.2.1"
+version = "26.3.1"
 dependencies = [
  "anyhow",
  "associative-cache",


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references in `.github/` workflow files to full-length commit SHAs

Generated by `devenv pin_gha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)