### PR TITLE
fix(linting): Changelog pre-commit fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,4 +219,3 @@ _Plus 8 more_
 - ci: Bring the release target back for images (#336) by @evanpurkhiser
 - ci: Fix bump-version script (#335) by @evanpurkhiser
 - craft: Add changelog (#334) by @evanpurkhiser
-


### PR DESCRIPTION
pre commit is failing on release branches since there is an extra newline: https://github.com/getsentry/uptime-checker/actions/runs/24472768968/job/71517139615