### PR TITLE
fix(gocd): exclude s4s2 from uptime-checker pipedream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4736,7 +4736,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uptime-checker"
-version = "26.5.2"
+version = "26.6.0"
 dependencies = [
  "anyhow",
  "associative-cache",

--- a/gocd/templates/pipelines/uptime-checker.libsonnet
+++ b/gocd/templates/pipelines/uptime-checker.libsonnet
@@ -14,7 +14,11 @@ local region_pops = {
     'us-east-sc',  // uptime-sc
     'us-east-va',  // uptime-va
   ],
-  us2: [],
+  us2: [
+    'us-west-or',  // uptime-or
+    'us-east-sc',  // uptime-sc
+    'us-east-va',  // uptime-va
+  ],
   s4s2: [],
 };
 

--- a/gocd/templates/uptime-checker.jsonnet
+++ b/gocd/templates/uptime-checker.jsonnet
@@ -19,7 +19,8 @@ local pipedream_config = {
     stage: 'deploy-primary',
     elastic_profile_id: 'uptime-checker',
   },
-  exclude_regions: ['customer-1', 'customer-2', 'customer-3', 'customer-4', 'customer-6', 'customer-7'],
+  // us2 and s4s2 have no uptime-checker POPs yet, so exclude them until they do (kept in sync with ops/gocd/templates/uptime-checker-k8s.jsonnet)
+  exclude_regions: ['us2', 's4s2', 'customer-1', 'customer-2', 'customer-3', 'customer-4', 'customer-6', 'customer-7'],
 };
 
 pipedream.render(pipedream_config, uptime_checker)

--- a/gocd/templates/uptime-checker.jsonnet
+++ b/gocd/templates/uptime-checker.jsonnet
@@ -20,7 +20,7 @@ local pipedream_config = {
     elastic_profile_id: 'uptime-checker',
   },
   // us2 and s4s2 have no uptime-checker POPs yet, so exclude them until they do (kept in sync with ops/gocd/templates/uptime-checker-k8s.jsonnet)
-  exclude_regions: ['us2', 's4s2', 'customer-1', 'customer-2', 'customer-3', 'customer-4', 'customer-6', 'customer-7'],
+  exclude_regions: ['s4s2', 'customer-1', 'customer-2', 'customer-3', 'customer-4', 'customer-6', 'customer-7'],
 };
 
 pipedream.render(pipedream_config, uptime_checker)


### PR DESCRIPTION
GoCD has been rejecting the uptime-checker config repo since the 2026-05-27 region rename. The generated `deploy-uptime-checker-us2` and `-s4s2` pipelines come out with empty `deploy-primary`, `deploy-canary`, and `scale-down-canary` stages, and GoCD won't accept a stage with no jobs, so the parse fails and the whole repo's config stays frozen on last-known-good.

Those stages generate one job per entry in `region_pops[region]`, and both `us2` and `s4s2` map to `[]` since uptime-checker has no POPs in those regions yet. The ops-side pipedream already excludes both (done in the same rename, getsentry/ops#20845), but this repo's copy was missed even though the libsonnet says to keep the two in sync.

Adding `us2` and `s4s2` to `exclude_regions` stops pipedream from generating those empty pipelines. When real POPs land in those regions we'll populate `region_pops` and drop them from the exclude list at the same time. The gocd-jsonnet validation in CI confirms the config parses.