### PR TITLE
fix(uptime): Handle redis broken pipes better

### DIFF
--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -131,7 +131,7 @@ impl RedisConfigProvider {
                 if let Err(err) = result {
                     tracing::error!(?err, "redis_config_provider.monitor_configs");
 
-                    // For reddis errors, wait and retry.
+                    // For redis errors, wait and retry.
                     tokio::time::sleep(Duration::from_secs(5)).await;
                 }
             }

--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -220,11 +220,7 @@ impl RedisConfigProvider {
         shutdown: CancellationToken,
         region: &'static str,
     ) -> Result<(), RedisError> {
-        let mut ops = self
-            .redis
-            .get_async_connection()
-            .await
-            .expect("Redis should be available");
+        let mut ops = self.redis.get_async_connection().await?;
         let mut interval = interval(self.check_interval);
 
         while !shutdown.is_cancelled() {

--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -2,6 +2,7 @@ use crate::{
     app::config::Config, manager::Manager, redis::RedisClient, types::check_config::CheckConfig,
 };
 use anyhow::Result;
+use redis::RedisError;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::sync::Arc;
@@ -122,8 +123,21 @@ impl RedisConfigProvider {
             .await;
 
         if !self.redis.is_readonly() {
-            self.monitor_updates(manager.clone(), &partitions, shutdown, region)
-                .await;
+            loop {
+                let result = self
+                    .monitor_updates(manager.clone(), &partitions, shutdown.clone(), region)
+                    .await;
+
+                match result {
+                    Ok(_) => break,
+                    Err(err) => {
+                        tracing::error!(?err, "redis_config_provider.monitor_configs");
+
+                        // For reddis errors, wait and retry.
+                        tokio::time::sleep(Duration::from_secs(5)).await;
+                    }
+                }
+            }
         }
     }
 
@@ -205,7 +219,7 @@ impl RedisConfigProvider {
         partitions: &[RedisPartition],
         shutdown: CancellationToken,
         region: &'static str,
-    ) {
+    ) -> Result<(), RedisError> {
         let mut ops = self
             .redis
             .get_async_connection()
@@ -226,7 +240,7 @@ impl RedisConfigProvider {
                 // We fetch all updates from the list and then delete the key. We do this
                 // atomically so that there isn't any chance of a race
                 let (config_upserts, config_deletes) =
-                    ops.consume_config_updates(&partition.update_key).await;
+                    ops.consume_config_updates(&partition.update_key).await?;
 
                 metrics::counter!("config_provider.updater.upserts", "uptime_region" => region, "partition" => partition.number.to_string())
                     .increment(config_upserts.len() as u64);
@@ -258,7 +272,7 @@ impl RedisConfigProvider {
                             .map(|config| config.redis_key())
                             .collect::<Vec<_>>(),
                     )
-                    .await;
+                    .await?;
 
                 for config_payload in config_payloads {
                     if let Some(config) = deserialize_rmp(&config_payload) {
@@ -292,6 +306,8 @@ impl RedisConfigProvider {
             )
             .record(update_duration);
         }
+
+        Ok(())
     }
 }
 

--- a/src/check_config_provider/redis_config_provider.rs
+++ b/src/check_config_provider/redis_config_provider.rs
@@ -123,19 +123,16 @@ impl RedisConfigProvider {
             .await;
 
         if !self.redis.is_readonly() {
-            loop {
+            while !shutdown.is_cancelled() {
                 let result = self
                     .monitor_updates(manager.clone(), &partitions, shutdown.clone(), region)
                     .await;
 
-                match result {
-                    Ok(_) => break,
-                    Err(err) => {
-                        tracing::error!(?err, "redis_config_provider.monitor_configs");
+                if let Err(err) = result {
+                    tracing::error!(?err, "redis_config_provider.monitor_configs");
 
-                        // For reddis errors, wait and retry.
-                        tokio::time::sleep(Duration::from_secs(5)).await;
-                    }
+                    // For reddis errors, wait and retry.
+                    tokio::time::sleep(Duration::from_secs(5)).await;
                 }
             }
         }

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -36,7 +36,7 @@ impl RedisOperations {
     pub async fn read_watermark(
         &mut self,
         progress_key: &String,
-    ) -> Result<Option<i64>, redis::RedisError> {
+    ) -> Result<Option<i64>, RedisError> {
         let conn = self.get_conn();
         let progress: Option<String> = conn.get(progress_key).await?;
 
@@ -48,16 +48,13 @@ impl RedisOperations {
         &mut self,
         progress_key: &String,
         progress: i64,
-    ) -> Result<(), redis::RedisError> {
+    ) -> Result<(), RedisError> {
         let conn = self.get_conn();
 
         conn.set(progress_key, progress.to_string()).await
     }
 
-    pub async fn read_configs(
-        &mut self,
-        config_key: &String,
-    ) -> Result<Vec<Vec<u8>>, redis::RedisError> {
+    pub async fn read_configs(&mut self, config_key: &String) -> Result<Vec<Vec<u8>>, RedisError> {
         let conn = self.get_conn();
         conn.hvals(config_key).await
     }
@@ -65,7 +62,7 @@ impl RedisOperations {
     pub async fn consume_config_updates(
         &mut self,
         update_key: &String,
-    ) -> (Vec<ConfigUpdate>, Vec<ConfigUpdate>) {
+    ) -> Result<(Vec<ConfigUpdate>, Vec<ConfigUpdate>), RedisError> {
         let conn = self
             .get_readwrite_conn()
             .expect("must be in read-write mode to access");
@@ -78,11 +75,7 @@ impl RedisOperations {
             .hvals(update_key)
             .del(update_key)
             .query_async::<(Vec<Vec<u8>>, ())>(conn)
-            .await
-            .unwrap_or_else(|err| {
-                tracing::error!(?err, "redis_config_provider.redis_query_failed");
-                (vec![], ())
-            })
+            .await?
             .0 // Get just the LRANGE results
             .iter()
             .map(|payload| {
@@ -100,21 +93,16 @@ impl RedisOperations {
                 (upserts, deletes)
             });
 
-        (config_upserts, config_deletes)
+        Ok((config_upserts, config_deletes))
     }
 
     pub async fn get_config_key_payloads(
         &mut self,
         config_key: &String,
         config_keys: Vec<String>,
-    ) -> Vec<Vec<u8>> {
+    ) -> Result<Vec<Vec<u8>>, RedisError> {
         let conn = self.get_conn();
-        conn.hget(config_key, config_keys)
-            .await
-            .unwrap_or_else(|err| {
-                tracing::error!(?err, "redis_config_provider.config_key_get_failed");
-                vec![]
-            })
+        conn.hget(config_key, config_keys).await
     }
 }
 


### PR DESCRIPTION
We just hit this in prod (and self-hosted folks noticed it a few weeks ago, coincidentally.)  If our connection to redis is broken, we don't try to make a new connection, leading to log spam and no longer retrieving updated configs.  This has the monitor_configs function handle redis errors (we still log, but now we sleep and retry the entire monitoring loop again.)