### PR TITLE
chore(gocd): bump gocd-jsonnet to v3.0.6

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v3.0.4"
+      "version": "v3.0.6"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "7a25c44956933a57b5ca03beb3b70c470724c2c8",
-      "sum": "0S+eGE0WHdxJxKS/Bdga+NB+cB+ZBwF4LoehKv0azXc="
+      "version": "ea9418700740024209261796c5bbe8e03de27a3e",
+      "sum": "fRk43jMWcGVSFHK6hJe5bipJaHYSYXByxqaHqdiiH/k="
     }
   ],
   "legacyImports": false

--- a/gocd/templates/uptime-checker.jsonnet
+++ b/gocd/templates/uptime-checker.jsonnet
@@ -20,7 +20,7 @@ local pipedream_config = {
     elastic_profile_id: 'uptime-checker',
   },
   // us2 and s4s2 have no uptime-checker POPs yet, so exclude them until they do (kept in sync with ops/gocd/templates/uptime-checker-k8s.jsonnet)
-  exclude_regions: ['s4s2', 'customer-1', 'customer-2', 'customer-3', 'customer-4', 'customer-6', 'customer-7'],
+  exclude_regions: ['us2', 's4s2', 'customer-1', 'customer-2', 'customer-3', 'customer-4', 'customer-6', 'customer-7'],
 };
 
 pipedream.render(pipedream_config, uptime_checker)


### PR DESCRIPTION
Bumps gocd-jsonnet to v3.0.6 for the single-region gate-skip fix in getsentry/gocd-jsonnet#97.