### PR TITLE
build: bump gocd-jsonnet to v3.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4665,7 +4665,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uptime-checker"
-version = "26.6.0"
+version = "26.7.1"
 dependencies = [
  "anyhow",
  "associative-cache",

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v3.0.6"
+      "version": "v3.0.7"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "ea9418700740024209261796c5bbe8e03de27a3e",
-      "sum": "fRk43jMWcGVSFHK6hJe5bipJaHYSYXByxqaHqdiiH/k="
+      "version": "5eac1ffce92df58ea41712ad8c82f55aa628350f",
+      "sum": "V0sY265XbQP5OVTjn8s/ZQdyRQHzndWNJs+wY1zgr8M="
     }
   ],
   "legacyImports": false

--- a/src/producer/kafka_producer.rs
+++ b/src/producer/kafka_producer.rs
@@ -63,8 +63,8 @@ mod tests {
         },
     };
     use chrono::{TimeDelta, Utc};
-    use sentry_arroyo::backends::kafka::config::KafkaConfig;
     use sentry::protocol::SpanId;
+    use sentry_arroyo::backends::kafka::config::KafkaConfig;
     use uuid::{uuid, Uuid};
 
     pub fn send_result(result: CheckStatus) -> Result<(), ExtractCodeError> {


### PR DESCRIPTION
Bumps the `gocd-jsonnet` dependency from `v3.0.6` to `v3.0.7`.

- Updated `gocd/templates/jsonnetfile.json` version pin
- Regenerated `gocd/templates/jsonnetfile.lock.json` via `jb update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)