### PR TITLE
ci: Replace curl-pipe-bash with action-setup-cli for Sentry CLI setup

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -123,7 +123,7 @@ jobs:
             -f Dockerfile .
 
       - name: Install sentry-cli
-        run: curl -sL https://sentry.io/get-cli/ | bash
+        uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
 
       - name: Upload debug symbols to Sentry
         run: scripts/upload-debug-symbols ./debug-out/uptime-checker.debug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uptime-checker"
-version = "26.7.1"
+version = "26.7.2"
 dependencies = [
  "anyhow",
  "associative-cache",

--- a/src/checker/reqwest_checker.rs
+++ b/src/checker/reqwest_checker.rs
@@ -738,7 +738,7 @@ mod tests {
     use chrono::{TimeDelta, Utc};
     use httpmock::prelude::*;
     use httpmock::Method;
-    
+
     use sentry::protocol::SpanId;
     use uuid::Uuid;
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary
- The "Install sentry-cli" step used `curl -sL https://sentry.io/get-cli/ | bash`, piping a remote install script directly into a shell.
- Replaced it with [`getsentry/action-setup-cli`](https://github.com/getsentry/action-setup-cli), which downloads the `sentry-cli` release asset for the runner's OS/arch and verifies its sha256 against the digest GitHub recorded for that asset via the Releases API, before adding it to `PATH`. Uses `gh` only, no `curl`.

## Test plan
- [x] Validated `image.yml` parses correctly
- [ ] Verify the `build-image-production` job still installs sentry-cli and uploads debug symbols correctly on this PR

Fixes VULN-2227

🤖 Generated with [Claude Code](https://claude.com/claude-code)