### PR TITLE
chore(gocd): use GitHub App credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uptime-checker"
-version = "26.7.2"
+version = "26.8.0"
 dependencies = [
  "anyhow",
  "associative-cache",

--- a/gocd/templates/pipelines/uptime-checker.libsonnet
+++ b/gocd/templates/pipelines/uptime-checker.libsonnet
@@ -30,7 +30,8 @@ local checks_stage = {
         timeout: 1200,
         elastic_profile_id: 'uptime-checker',
         environment_variables: {
-          GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+          GITHUB_APP_ID: '{{SECRET:[devinfra-github][app_id]}}',
+          GITHUB_APP_PRIVATE_KEY: '{{SECRET:[devinfra-github][private_key]}}',
         },
         tasks: [
           gocdtasks.script(importstr '../bash/check-github-runs.sh'),


### PR DESCRIPTION
Replace GoCD GitHub token references with GitHub App credentials.

- Pass GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY to GoCD jobs.
- Preserve legacy runtime compatibility where the existing helper supports it.